### PR TITLE
docs: correct config file to turbo-desktop.config.json (JSON, not TOML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,18 @@ npm install
 
 ### 2. Configure your Rails server URL
 
-Edit `turbo-desktop.toml`:
+Edit `turbo-desktop.config.json`:
 
-```toml
-[app]
-server_url = "http://localhost:3000"
-app_name   = "My App"
-
-[path_configuration]
-url = "http://localhost:3000/turbo-desktop/path-configuration.json"
+```json
+{
+  "server_url": "http://localhost:3000",
+  "app_name": "My App",
+  "path_configuration_url": "http://localhost:3000/turbo-desktop/path-configuration.json"
+}
 ```
+
+> `path_configuration_url` is optional — it defaults to
+> `{server_url}/turbo-desktop/path-configuration.json`.
 
 ### 3. Add the Rails gem
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -588,7 +588,7 @@
       <div class="step-content">
         <h3>The Tauri shell loads your Rails URL</h3>
         <p>
-          On launch, Rust reads <code>turbo-desktop.toml</code> for your <code>server_url</code>,
+          On launch, Rust reads <code>turbo-desktop.config.json</code> for your <code>server_url</code>,
           then navigates the main WebView window to that URL with <code>window.location.replace()</code>.
         </p>
         <pre><code><span class="cm">// main.rs — startup</span>
@@ -931,13 +931,12 @@ npm install</code></pre>
       <div class="step-number">2</div>
       <div class="step-content">
         <h3>Configure your Rails server URL</h3>
-        <p>Edit <code>turbo-desktop.toml</code> (or the relevant config) to point at your running Rails app:</p>
-        <pre><code>[app]
-server_url = <span class="st">"http://localhost:3000"</span>
-app_name   = <span class="st">"My App"</span>
-
-[path_configuration]
-url = <span class="st">"http://localhost:3000/turbo-desktop/path-configuration.json"</span></code></pre>
+        <p>Edit <code>turbo-desktop.config.json</code> to point at your running Rails app:</p>
+        <pre><code>{
+  <span class="st">"server_url"</span>: <span class="st">"http://localhost:3000"</span>,
+  <span class="st">"app_name"</span>: <span class="st">"My App"</span>,
+  <span class="st">"path_configuration_url"</span>: <span class="st">"http://localhost:3000/turbo-desktop/path-configuration.json"</span>
+}</code></pre>
       </div>
     </div>
 


### PR DESCRIPTION
## What

The quick-start in `README.md` and the docs site (`docs/index.html`) told users to configure `turbo-desktop.toml`, but the config loader in `src-tauri/src/window.rs` only reads **`turbo-desktop.config.json`** (JSON). No `.toml` file is ever parsed.

Following the docs verbatim silently left the shell on defaults — `server_url` and friends were never picked up.

## Changes

- `README.md` quick-start: TOML snippet → JSON matching the real schema (`server_url`, `app_name`, `path_configuration_url`).
- `docs/index.html`: two spots — the "Rust reads …" description and the config example.
- Documented `path_configuration_url` as optional (loader defaults it to `{server_url}/turbo-desktop/path-configuration.json`).

## Verification

Schema cross-checked against `TurboDesktopConfig` in `src-tauri/src/window.rs`; filename against the loader default (`window.rs`) and the CLI writer (`cli/turbo-desktop.js`). Docs-only change — no code touched.