### PR TITLE
chore(rails): add missing gem metadata (README, LICENSE, CHANGELOG)

### DIFF
--- a/turbo_desktop-rails/CHANGELOG.md
+++ b/turbo_desktop-rails/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.0.1 (2026-03-22)
+
+- Initial release
+- User-Agent detection for Turbo Desktop apps (`turbo_desktop_app?`)
+- Platform and architecture detection (`turbo_desktop_platform`, `turbo_desktop_arch`)
+- View helpers for conditional rendering (`turbo_desktop_only`, `turbo_web_only`)
+- Bridge component data attribute helper (`turbo_desktop_bridge`)
+- Path configuration endpoint (`/turbo-desktop/path-configuration.json`)
+- Configurable path configuration rules and User-Agent pattern

--- a/turbo_desktop-rails/LICENSE
+++ b/turbo_desktop-rails/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 RaiderHQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/turbo_desktop-rails/README.md
+++ b/turbo_desktop-rails/README.md
@@ -1,0 +1,85 @@
+# turbo_desktop-rails
+
+Server-side Rails integration for [Turbo Desktop](https://github.com/aguspe/turbo_desktop) — the Turbo Native pattern for desktop apps.
+
+This gem gives your Rails app awareness of the Turbo Desktop shell, exactly like `turbo-rails` does for Turbo Native mobile apps.
+
+## Installation
+
+Add to your Gemfile:
+
+```ruby
+gem "turbo_desktop-rails"
+```
+
+Then run:
+
+```bash
+bundle install
+rails generate turbo_desktop:install
+```
+
+## Usage
+
+### Detection
+
+The gem detects Turbo Desktop requests via the User-Agent header (`Turbo Desktop/0.0.1 (macOS; aarch64)`).
+
+```ruby
+# In controllers
+if turbo_desktop_app?
+  # Desktop-specific logic
+end
+
+turbo_desktop_platform  # => "macos", "windows", "linux", or nil
+turbo_desktop_arch      # => "aarch64", "x86_64", or nil
+```
+
+### View Helpers
+
+```erb
+<%# Render only inside the desktop app %>
+<% turbo_desktop_only do %>
+  <button data-controller="sidebar">Toggle Sidebar</button>
+<% end %>
+
+<%# Render only for regular web browsers %>
+<% turbo_web_only do %>
+  <nav class="web-navbar">...</nav>
+<% end %>
+
+<%# Bridge component data attributes %>
+<%= tag.button "Export PDF",
+    **turbo_desktop_bridge("menu-item",
+      title: "Export PDF",
+      shortcut: "Cmd+E"
+    ) %>
+```
+
+### Path Configuration
+
+The gem mounts a path configuration endpoint at `/turbo-desktop/path-configuration.json`:
+
+```ruby
+# config/initializers/turbo_desktop.rb
+TurboDesktop.configure do |config|
+  config.path_configuration = {
+    settings: { screenshots_enabled: true },
+    rules: [
+      { patterns: ["/"], properties: { presentation: "default" } },
+      { patterns: ["/new$", "/edit$"], properties: { presentation: "modal" } },
+      { patterns: ["/settings"], properties: { presentation: "native" } }
+    ]
+  }
+end
+```
+
+## Requirements
+
+- Ruby >= 3.1.0
+- Rails >= 7.0
+- turbo-rails >= 1.0
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## What

The `turbo_desktop-rails` gem had its `lib/`, generators, and tests tracked, but its **README.md**, **LICENSE**, and **CHANGELOG.md** were never committed — they only existed on disk. These are the files a gem needs before it can be published to RubyGems or trusted by contributors.

## Changes

Adds the three metadata files as-is. No code change.

## Heads-up (not addressed here)

- `LICENSE` copyright holder reads **"RaiderHQ"** — confirm that's intended vs `aguspe`.
- `CHANGELOG.md` stops at `0.0.1`; a `0.1.1` gem is already built. Worth a changelog entry before the next publish.