### PR TITLE
chore: gitignore build artifacts and local run config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,15 @@ Thumbs.db
 # Local scratch / test scaffolds
 debug_project/
 test_raider_project/
+
+# Local clone of the separate example-app repo (github.com/aguspe/turbo_desktop_example_app)
+turbo_desktop_example_app/
+
+# Built gem artifacts — ship via RubyGems / GitHub Releases, not git
+turbo_desktop-rails/*.gem
+
+# Gem test scratch output
+turbo_desktop-rails/test/tmp/
+
+# Local desktop run config (per-app / per-user; not part of the shell source)
+/turbo-desktop.config.json


### PR DESCRIPTION
## What

Stop tracking files that shouldn't be versioned, keeping the working tree clean for contributors.

## Ignored

- `turbo_desktop_example_app/` — a local clone of the separate [`aguspe/turbo_desktop_example_app`](https://github.com/aguspe/turbo_desktop_example_app) repo. Committing it would embed a stray gitlink, not the files.
- `turbo_desktop-rails/*.gem` — built gem artifacts; ship via RubyGems / GitHub Releases, not git.
- `turbo_desktop-rails/test/tmp/` — test scratch output.
- `/turbo-desktop.config.json` (root-anchored) — a local, per-app run config; each user configures their own. Per-app `desktop/turbo-desktop.config.json` files elsewhere are unaffected.

## Follow-up (not here)

Consider adding a committed `turbo-desktop.config.example.json` so a fresh clone can `cargo tauri dev` without falling back to defaults.