### PR TITLE
docs: add CONTRIBUTING guide and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: "[Bug]: "
+labels: [bug]
+---
+
+## What happened
+
+<!-- A clear description of the bug. -->
+
+## What you expected
+
+<!-- What should have happened instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- **OS + version:** <!-- e.g. macOS 15.1 (arm64), Windows 11, Ubuntu 24.04 -->
+- **Turbo Desktop version / commit:**
+- **`turbo_desktop-rails` gem version:**
+- **Ruby + Rails version:**
+- **Tauri version:** <!-- from src-tauri/Cargo.toml, or `cargo tauri --version` -->
+
+## `turbo-desktop.config.json`
+
+<!-- Paste your config (redact anything private). -->
+
+```json
+
+```
+
+## Logs / errors
+
+<!-- Console output, Rust panic, Rails log, or Dev Inspector "Messages" panel output. -->
+
+```
+
+```
+
+## Additional context
+
+<!-- Screenshots, path-configuration rules, or anything else that helps. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/aguspe/turbo_desktop/discussions
+    about: Ask questions and share ideas here instead of opening an issue.
+  - name: Documentation
+    url: https://aguspe.github.io/turbo_desktop/
+    about: Check the docs before filing — your answer may already be there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for Turbo Desktop
+title: "[Feature]: "
+labels: [enhancement]
+---
+
+## Problem / motivation
+
+<!-- What are you trying to do that Turbo Desktop makes hard or impossible today? -->
+
+## Proposed solution
+
+<!-- What you'd like to happen. -->
+
+## Which part does this touch?
+
+<!-- Check any that apply. -->
+
+- [ ] Tauri/Rust shell (`src-tauri/`)
+- [ ] JS bridge (`src/`, `packages/bridge/`)
+- [ ] Rails gem (`turbo_desktop-rails/`)
+- [ ] CLI (`cli/`)
+- [ ] Docs
+- [ ] Bridge component (e.g. notification, menu, tray)
+
+## Alternatives considered
+
+<!-- Other approaches, workarounds, or related tools. -->
+
+## Additional context
+
+<!-- Mockups, links, prior art from turbo-ios / turbo-android, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thanks for contributing to Turbo Desktop! Keep PRs to one concern. -->
+
+## What & why
+
+<!-- What does this change and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #12 -->
+
+## Which part does this touch?
+
+- [ ] Tauri/Rust shell (`src-tauri/`)
+- [ ] JS bridge (`src/`, `packages/bridge/`)
+- [ ] Rails gem (`turbo_desktop-rails/`)
+- [ ] CLI (`cli/`)
+- [ ] Docs
+
+## Checklist
+
+- [ ] One concern per PR
+- [ ] Tests added/updated for behaviour changes
+- [ ] Relevant suite passes locally (`bundle exec rake test` / `npm test` / `cargo check`)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Turbo Desktop
+
+Thanks for your interest in Turbo Desktop — the [Hotwire Native](https://native.hotwired.dev/)
+pattern brought to the desktop. Contributions of all kinds are welcome: bug reports, docs,
+tests, and features.
+
+## Ways to help
+
+- **Report a bug** — open an issue using the *Bug report* template.
+- **Request a feature** — open an issue using the *Feature request* template.
+- **Pick up a "good first issue"** — see the [issues](https://github.com/aguspe/turbo_desktop/issues)
+  labelled `good first issue`.
+- **Improve docs** — the README and the docs site (`docs/`) are always improvable.
+
+## Project layout
+
+Turbo Desktop is three pieces in one repo:
+
+| Path | What it is |
+|------|-----------|
+| `src-tauri/` | The Rust/Tauri desktop shell (window mgmt, path-config routing, OS APIs). |
+| `src/`, `packages/bridge/` | The JS layer (`turbo-desktop.js`) that intercepts Turbo visits and bridges to native. |
+| `turbo_desktop-rails/` | The Rails gem — desktop-shell awareness, view helpers, path-configuration endpoint. |
+| `cli/` | The `turbo-desktop` CLI (`npx turbo-desktop new myapp`). |
+| `docs/`, `site/` | Documentation site. |
+
+## Development setup
+
+```bash
+git clone https://github.com/aguspe/turbo_desktop.git
+cd turbo_desktop
+cargo install tauri-cli   # if you don't have it
+npm install
+```
+
+Configure the shell via `turbo-desktop.config.json` (JSON) — see the README quick-start.
+Turbo Desktop points a WebView at a **running Rails app** (`server_url`), so start your Rails
+server, then run the shell:
+
+```bash
+bin/rails server   # your Rails app (terminal 1)
+cargo tauri dev    # the desktop shell (terminal 2)
+```
+
+## Running the tests
+
+Please run the suite for whichever piece you touched (CI runs all three):
+
+```bash
+# Rails gem
+cd turbo_desktop-rails && bundle exec rake test
+
+# JavaScript
+npm test
+
+# Rust shell
+cd src-tauri && cargo check      # cargo test once Rust tests exist
+```
+
+## Pull requests
+
+- **One concern per PR.** Small, focused PRs are reviewed and merged faster.
+- Add or update tests for behaviour changes.
+- Make sure the relevant test suite passes locally before opening the PR.
+- **Commit messages:** please use [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, optionally scoped like `fix(inspector):`).
+  It keeps history readable and helps changelog generation.
+- Reference the issue your PR addresses (e.g. `Closes #12`).
+
+## Reporting security issues
+
+Please **do not** open a public issue for security vulnerabilities. Instead, contact the
+maintainer privately (see the repo profile) so it can be addressed before disclosure.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's
+[MIT License](LICENSE).


### PR DESCRIPTION
## What

Adds a contributor on-ramp — requested to make the project easier to contribute to and better maintained.

- **CONTRIBUTING.md** — project layout (shell / JS / gem / CLI), dev setup, how to run each test suite (`bundle exec rake test`, `npm test`, `cargo check`), and PR conventions (Conventional Commits, one concern per PR, MIT).
- **.github/ISSUE_TEMPLATE/** — Bug report (OS, Turbo Desktop / gem / Ruby / Rails / Tauri versions, config, logs) and Feature request, plus `config.yml` routing questions to Discussions and the docs site.
- **.github/PULL_REQUEST_TEMPLATE.md** — concern-scoped checklist.

## Note

CONTRIBUTING recommends Conventional Commits as the go-forward convention (my recent PRs model it); it's not retroactively enforced on existing history.