### PR TITLE
chore(rails): add RuboCop (omakase) + lint CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,21 @@ jobs:
           working-directory: turbo_desktop-rails
       - run: bundle exec rake test
 
+  lint:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: turbo_desktop-rails
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+          working-directory: turbo_desktop-rails
+      - run: bundle exec rubocop --format github
+
   javascript:
     name: JavaScript Tests
     runs-on: ubuntu-latest

--- a/turbo_desktop-rails/.rubocop.yml
+++ b/turbo_desktop-rails/.rubocop.yml
@@ -1,0 +1,10 @@
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 3.2
+  NewCops: enable
+  Exclude:
+    - "test/tmp/**/*"
+    - "bin/**/*"
+    - "vendor/**/*"

--- a/turbo_desktop-rails/Gemfile
+++ b/turbo_desktop-rails/Gemfile
@@ -6,3 +6,5 @@ gem "rake"
 gem "minitest", "~> 5.0"
 gem "rails", ">= 7.0"
 gem "turbo-rails", ">= 1.0"
+
+gem "rubocop-rails-omakase", require: false

--- a/turbo_desktop-rails/Gemfile.lock
+++ b/turbo_desktop-rails/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.0.1)
     builder (3.3.0)
@@ -103,6 +104,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.2)
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -142,6 +145,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
+    parallel (2.1.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -188,13 +195,44 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.1)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.36.0)
+      activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
+      rack (>= 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rails-omakase (1.1.0)
+      rubocop (>= 1.72)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.30)
+    ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     stringio (3.2.0)
     thor (1.5.0)
@@ -205,6 +243,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
     websocket-driver (0.8.0)
@@ -227,6 +268,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   rails (>= 7.0)
   rake
+  rubocop-rails-omakase
   turbo-rails (>= 1.0)
   turbo_desktop-rails!
 
@@ -243,6 +285,7 @@ CHECKSUMS
   activerecord (8.1.2) sha256=acfbe0cadfcc50fa208011fe6f4eb01cae682ebae0ef57145ba45380c74bcc44
   activestorage (8.1.2) sha256=8a63a48c3999caeee26a59441f813f94681fc35cc41aba7ce1f836add04fba76
   activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
@@ -258,6 +301,8 @@ CHECKSUMS
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
@@ -277,6 +322,8 @@ CHECKSUMS
   nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
@@ -290,9 +337,17 @@ CHECKSUMS
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   railties (8.1.2) sha256=1289ece76b4f7668fc46d07e55cc992b5b8751f2ad85548b7da351b8c59f8055
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rails (2.36.0) sha256=105a5f5b0001ff2ef28a3af90da50862464e0775e8d0016d599079c0ca408bdb
+  rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
@@ -301,6 +356,8 @@ CHECKSUMS
   turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
   turbo_desktop-rails (0.1.1)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962

--- a/turbo_desktop-rails/lib/turbo_desktop/configuration.rb
+++ b/turbo_desktop-rails/lib/turbo_desktop/configuration.rb
@@ -19,7 +19,7 @@ module TurboDesktop
           screenshots_enabled: false
         },
         rules: [
-          { patterns: ["/"], properties: { presentation: "default" } }
+          { patterns: [ "/" ], properties: { presentation: "default" } }
         ]
       }
     end

--- a/turbo_desktop-rails/test/configuration_test.rb
+++ b/turbo_desktop-rails/test/configuration_test.rb
@@ -17,7 +17,7 @@ class ConfigurationTest < Minitest::Test
     config = TurboDesktop::Configuration.new
     rules = config.path_configuration[:rules]
     assert_equal 1, rules.length
-    assert_equal ["/"], rules.first[:patterns]
+    assert_equal [ "/" ], rules.first[:patterns]
     assert_equal "default", rules.first[:properties][:presentation]
   end
 
@@ -34,7 +34,7 @@ class ConfigurationTest < Minitest::Test
     custom = {
       settings: { screenshots_enabled: true },
       rules: [
-        { patterns: ["/new"], properties: { presentation: "modal" } }
+        { patterns: [ "/new" ], properties: { presentation: "modal" } }
       ]
     }
     config.path_configuration = custom
@@ -57,8 +57,8 @@ class ConfigurationTest < Minitest::Test
     config.path_configuration = {
       settings: { screenshots_enabled: true },
       rules: [
-        { patterns: ["/modal"], properties: { presentation: "modal" } },
-        { patterns: ["/"], properties: { presentation: "default" } }
+        { patterns: [ "/modal" ], properties: { presentation: "modal" } },
+        { patterns: [ "/" ], properties: { presentation: "default" } }
       ]
     }
     parsed = JSON.parse(config.path_configuration_json)
@@ -78,7 +78,7 @@ class ConfigurationTest < Minitest::Test
   def test_configure_block_sets_path_configuration
     custom_rules = {
       settings: {},
-      rules: [{ patterns: ["/admin"], properties: { presentation: "native" } }]
+      rules: [ { patterns: [ "/admin" ], properties: { presentation: "native" } } ]
     }
     TurboDesktop.configure do |config|
       config.path_configuration = custom_rules

--- a/turbo_desktop-rails/test/path_configurations_controller_test.rb
+++ b/turbo_desktop-rails/test/path_configurations_controller_test.rb
@@ -36,7 +36,7 @@ class PathConfigurationsControllerTest < ActionDispatch::IntegrationTest
     assert body.key?("rules")
     assert_equal false, body["settings"]["screenshots_enabled"]
     assert_equal 1, body["rules"].length
-    assert_equal ["/"], body["rules"].first["patterns"]
+    assert_equal [ "/" ], body["rules"].first["patterns"]
     assert_equal "default", body["rules"].first["properties"]["presentation"]
   end
 
@@ -45,8 +45,8 @@ class PathConfigurationsControllerTest < ActionDispatch::IntegrationTest
       config.path_configuration = {
         settings: { screenshots_enabled: true },
         rules: [
-          { patterns: ["/new", "/edit"], properties: { presentation: "modal" } },
-          { patterns: ["/"], properties: { presentation: "default" } }
+          { patterns: [ "/new", "/edit" ], properties: { presentation: "modal" } },
+          { patterns: [ "/" ], properties: { presentation: "default" } }
         ]
       }
     end

--- a/turbo_desktop-rails/turbo_desktop-rails.gemspec
+++ b/turbo_desktop-rails/turbo_desktop-rails.gemspec
@@ -3,8 +3,8 @@ require_relative "lib/turbo_desktop/version"
 Gem::Specification.new do |spec|
   spec.name          = "turbo_desktop-rails"
   spec.version       = TurboDesktop::VERSION
-  spec.authors       = ["RaiderHQ"]
-  spec.email         = ["hello@raiderhq.com"]
+  spec.authors       = [ "RaiderHQ" ]
+  spec.email         = [ "hello@raiderhq.com" ]
 
   spec.summary       = "Turbo Native for Desktop — Rails integration"
   spec.description   = "Server-side helpers for Turbo Desktop: User-Agent detection, view helpers, and path configuration endpoint for desktop apps built with Turbo/Hotwire."
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["lib/**/*", "app/**/*", "config/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
-  spec.require_paths = ["lib"]
+  spec.require_paths = [ "lib" ]
 
   spec.add_dependency "rails", ">= 7.0"
   spec.add_dependency "turbo-rails", ">= 1.0"


### PR DESCRIPTION
## What

Establishes a consistent Ruby style for the `turbo_desktop-rails` gem.

- Adopts **rubocop-rails-omakase** (Rails 8's default style) as a dev dependency + `.rubocop.yml` (`TargetRubyVersion: 3.2`; excludes `test/tmp`, `bin`).
- Autocorrected gem source + tests — **whitespace / array-bracket spacing only, no behaviour change**. All 51 gem tests pass; `rubocop` reports 0 offenses.
- Adds a **RuboCop** CI job.

_(Replaces #9, which GitHub auto-closed when its stacked base branch `fix/ci-lockfile-sync` was deleted on merge of #8. Rebased cleanly onto main.)_