### PR TITLE
fix(ci): pin parallel < 2.1 to keep Ruby 3.2 green

### DIFF
--- a/turbo_desktop-rails/Gemfile
+++ b/turbo_desktop-rails/Gemfile
@@ -8,3 +8,7 @@ gem "rails", ">= 7.0"
 gem "turbo-rails", ">= 1.0"
 
 gem "rubocop-rails-omakase", require: false
+# Pin parallel < 2.1: 2.1.0 requires Ruby >= 3.3, which would break the
+# gem's supported Ruby 3.2 in CI. rubocop is dev-only, so it must not
+# raise the gem's Ruby floor.
+gem "parallel", "< 2.1", require: false

--- a/turbo_desktop-rails/Gemfile.lock
+++ b/turbo_desktop-rails/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
-    parallel (2.1.0)
+    parallel (2.0.1)
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
@@ -266,6 +266,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest (~> 5.0)
+  parallel (< 2.1)
   rails (>= 7.0)
   rake
   rubocop-rails-omakase
@@ -322,7 +323,7 @@ CHECKSUMS
   nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
-  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parallel (2.0.1) sha256=337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193


### PR DESCRIPTION
Adding rubocop (#10) pulled `parallel 2.1.0`, which requires Ruby >= 3.3 — breaking the Ruby 3.2 CI leg (`bundle install` exit 5). rubocop is dev-only and must not raise the gem's Ruby floor, so pin `parallel < 2.1` (resolves to 2.0.1). rubocop still clean; 51 tests pass.

Hotfix for the regression #10 introduced on main.