### PR TITLE
fix(ci): raise Ruby floor to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.3", "3.4"]
     defaults:
       run:
         working-directory: turbo_desktop-rails

--- a/turbo_desktop-rails/.rubocop.yml
+++ b/turbo_desktop-rails/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-rails-omakase: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
   Exclude:
     - "test/tmp/**/*"

--- a/turbo_desktop-rails/Gemfile
+++ b/turbo_desktop-rails/Gemfile
@@ -8,7 +8,3 @@ gem "rails", ">= 7.0"
 gem "turbo-rails", ">= 1.0"
 
 gem "rubocop-rails-omakase", require: false
-# Pin parallel < 2.1: 2.1.0 requires Ruby >= 3.3, which would break the
-# gem's supported Ruby 3.2 in CI. rubocop is dev-only, so it must not
-# raise the gem's Ruby floor.
-gem "parallel", "< 2.1", require: false

--- a/turbo_desktop-rails/Gemfile.lock
+++ b/turbo_desktop-rails/Gemfile.lock
@@ -266,7 +266,6 @@ PLATFORMS
 
 DEPENDENCIES
   minitest (~> 5.0)
-  parallel (< 2.1)
   rails (>= 7.0)
   rake
   rubocop-rails-omakase

--- a/turbo_desktop-rails/turbo_desktop-rails.gemspec
+++ b/turbo_desktop-rails/turbo_desktop-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/aguspe/turbo_desktop"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["homepage_uri"]      = spec.homepage
   spec.metadata["source_code_uri"]   = spec.homepage


### PR DESCRIPTION
The rubocop toolchain (`parallel` 2.x) requires Ruby >= 3.3, so the dev/CI bundle can't install on 3.2 (`bundle` exit 5). Rather than pin a chain of stale transitive deps to keep 3.2 alive, raise the gem's floor to **Ruby 3.3** — reasonable for a 2026 Rails 8 gem.

- CI matrix: `3.3, 3.4` (drop 3.2)
- `required_ruby_version >= 3.3.0`
- RuboCop `TargetRubyVersion: 3.3`
- remove the now-unneeded `parallel` pin

Supersedes the #11 pin approach. rubocop clean, 51 tests pass locally.