### PR TITLE
ci: test on Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.3", "3.4"]
+        ruby: ["3.3", "3.4", "4.0"]
     defaults:
       run:
         working-directory: turbo_desktop-rails


### PR DESCRIPTION
Adds `4.0` to the Ruby test matrix (now `3.3, 3.4, 4.0`). Ruby 4.0.2 is stable (released 2026-03) and the gem already runs on it locally — the committed `Gemfile.lock` and tests were generated under 4.0.2. `required_ruby_version >= 3.3.0` already permits 4.x.