### PR TITLE
feat(rails): serve the Dev Inspector JS from the gem (same-origin)

### DIFF
--- a/src/turbo-desktop.js
+++ b/src/turbo-desktop.js
@@ -497,9 +497,17 @@
   TurboDesktop._inspectorEnabled = inspectorEnabled;
 
   if (INVOKE && inspectorEnabled()) {
-    // The Tauri shell sets __TURBO_DESKTOP_INSPECTOR_URL__ to the injected
-    // asset URL; fall back to a relative path for bundled setups.
-    var inspectorUrl = window.__TURBO_DESKTOP_INSPECTOR_URL__ || "./inspector.js";
+    // Resolve the inspector entry URL, in priority order:
+    //   1. an explicit override global,
+    //   2. the same-origin URL the Rails gem advertises on the meta tag
+    //      (turbo_desktop_inspector_meta_tag → data-inspector-url), served by
+    //      the gem's engine so this import() is same-origin,
+    //   3. a relative fallback for setups that serve ./inspector.js themselves.
+    var inspectorMeta = document.querySelector('meta[name="turbo-desktop-inspector"]');
+    var inspectorUrl =
+      window.__TURBO_DESKTOP_INSPECTOR_URL__ ||
+      (inspectorMeta && inspectorMeta.dataset && inspectorMeta.dataset.inspectorUrl) ||
+      "./inspector.js";
     import(inspectorUrl)
       .then(function (m) { m.startInspector(TurboDesktop, { doc: document, win: window }); })
       .catch(function (e) { console.error("[turbo-desktop] inspector failed to load", e); });

--- a/turbo_desktop-rails/Rakefile
+++ b/turbo_desktop-rails/Rakefile
@@ -6,4 +6,20 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
+namespace :turbo_desktop do
+  desc "Vendor the Dev Inspector JS from the shell (../src) into the gem for same-origin serving"
+  task :sync_inspector do
+    require "fileutils"
+    shell_src = File.expand_path("../src", __dir__)
+    dest = File.expand_path("lib/turbo_desktop/inspector_assets", __dir__)
+    files = %w[inspector.js inspector/state.js inspector/panel.js inspector/bridge-tap.js inspector/catalog.js]
+    abort "shell src not found at #{shell_src}" unless File.directory?(shell_src)
+    files.each do |file|
+      FileUtils.mkdir_p(File.dirname(File.join(dest, file)))
+      FileUtils.cp(File.join(shell_src, file), File.join(dest, file))
+      puts "synced #{file}"
+    end
+  end
+end
+
 task default: :test

--- a/turbo_desktop-rails/app/controllers/turbo_desktop/inspector_assets_controller.rb
+++ b/turbo_desktop-rails/app/controllers/turbo_desktop/inspector_assets_controller.rb
@@ -1,0 +1,44 @@
+module TurboDesktop
+  # Serves the Dev Inspector's JavaScript from the Rails origin so the desktop
+  # shell's `turbo-desktop.js` can `import()` it same-origin.
+  #
+  # The shell points its WebView at your Rails app (server_url), so a relative
+  # `import("./inspector.js")` resolves against the Rails origin — which is why
+  # these assets must be served here, not from the bundled Tauri frontend.
+  #
+  # Only the fixed set of inspector modules is served (strict allow-list, so no
+  # path traversal). Enabled implicitly by mounting the engine; the meta-tag
+  # helper points the shell at these URLs.
+  class InspectorAssetsController < ActionController::Base
+    ASSET_ROOT = TurboDesktop::Engine.root.join("lib/turbo_desktop/inspector_assets").freeze
+
+    # Relative paths (as requested by the browser) → allowed. Anything else 404s.
+    ALLOWED = %w[
+      inspector.js
+      inspector/state.js
+      inspector/panel.js
+      inspector/bridge-tap.js
+      inspector/catalog.js
+    ].freeze
+
+    # GET /turbo-desktop/inspector.js
+    # GET /turbo-desktop/inspector/<module>.js
+    def show
+      rel = requested_asset
+      return head(:not_found) unless ALLOWED.include?(rel)
+
+      path = ASSET_ROOT.join(rel)
+      return head(:not_found) unless File.file?(path)
+
+      response.set_header("Cache-Control", "public, max-age=3600")
+      render body: File.read(path), content_type: "text/javascript"
+    end
+
+    private
+
+    def requested_asset
+      mod = params[:module]
+      mod.blank? ? "inspector.js" : "inspector/#{mod}"
+    end
+  end
+end

--- a/turbo_desktop-rails/config/routes.rb
+++ b/turbo_desktop-rails/config/routes.rb
@@ -1,3 +1,7 @@
 TurboDesktop::Engine.routes.draw do
   get "path-configuration", to: "path_configurations#show", defaults: { format: :json }
+
+  # Dev Inspector assets, served same-origin so the desktop shell can import() them.
+  get "inspector.js", to: "inspector_assets#show", format: false
+  get "inspector/*module", to: "inspector_assets#show", format: false
 end

--- a/turbo_desktop-rails/lib/turbo_desktop/configuration.rb
+++ b/turbo_desktop-rails/lib/turbo_desktop/configuration.rb
@@ -1,11 +1,14 @@
 module TurboDesktop
   class Configuration
-    attr_accessor :path_configuration, :user_agent_pattern, :inspector_enabled
+    attr_accessor :path_configuration, :user_agent_pattern, :inspector_enabled, :inspector_mount_path
 
     def initialize
       @path_configuration = default_path_configuration
       @user_agent_pattern = /Turbo Desktop/
       @inspector_enabled = false
+      # Where the engine is mounted; the inspector meta tag advertises assets
+      # under this prefix. Override if you mount the engine elsewhere.
+      @inspector_mount_path = "/turbo-desktop"
     end
 
     def path_configuration_json

--- a/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector.js
+++ b/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector.js
@@ -1,0 +1,57 @@
+/**
+ * Dev Inspector entry point.
+ *
+ * startInspector(host, env) wires the inspector units onto a TurboDesktop-like
+ * host: it installs a BridgeTap on the host's sendBridgeMessage, subscribes to
+ * inbound bridge-response events, seeds shell facts, mounts the Shadow-DOM
+ * panel, and binds the toggle hotkey (Cmd/Ctrl+Shift+D).
+ *
+ * This module is loaded lazily by turbo-desktop.js only when the inspector gate
+ * passes, so it ships no code to production builds.
+ */
+import { BridgeTap } from "./inspector/bridge-tap.js";
+import { InspectorState } from "./inspector/state.js";
+import { InspectorPanel } from "./inspector/panel.js";
+
+export function startInspector(host, { doc = document, win = window } = {}) {
+  const state = new InspectorState();
+
+  const now = (win.Date && typeof win.Date.now === "function") ? () => win.Date.now() : () => 0;
+  const tap = new BridgeTap(host, { onRecord: (r) => state.record(r), now });
+  tap.install();
+
+  const internals = win.__TAURI_INTERNALS__;
+  if (internals && internals.event && typeof internals.event.listen === "function") {
+    internals.event.listen("bridge-response", (e) => tap.observeResponse(e && e.payload));
+  }
+
+  state.setShell({ platform: host.platform, version: host.version });
+  if (typeof host.getWindowInfo === "function") {
+    host.getWindowInfo().then((info) => { if (info) state.setShell(info); }).catch(() => {});
+  }
+
+  if (typeof host.proposeVisit === "function") {
+    const originalProposeVisit = host.proposeVisit.bind(host);
+    host.proposeVisit = async function (url, action) {
+      const result = await originalProposeVisit(url, action);
+      try {
+        state.setNav({ url, presentation: result && result.presentation ? result.presentation : "default" });
+      } catch (_e) { /* nav recording must never break navigation */ }
+      return result;
+    };
+  }
+
+  const panel = new InspectorPanel(state, { document: doc });
+  panel.mount(doc.body);
+
+  win.addEventListener("keydown", (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "D" || e.key === "d")) {
+      e.preventDefault();
+      panel.toggle();
+    }
+  });
+
+  return { state, tap, panel };
+}
+
+export default startInspector;

--- a/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/bridge-tap.js
+++ b/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/bridge-tap.js
@@ -1,0 +1,59 @@
+/**
+ * Observes bridge traffic without altering it.
+ *
+ * install() wraps host.sendBridgeMessage so every outbound call is recorded
+ * then forwarded to the original exactly once, with its return/throw preserved.
+ * observeResponse() records inbound bridge-response payloads.
+ *
+ * Recording runs inside its own try/catch so a logging bug can never affect a
+ * real bridge call. No DOM access.
+ */
+export class BridgeTap {
+  constructor(host, { onRecord, now = () => Date.now() } = {}) {
+    this.host = host;
+    this.onRecord = onRecord;
+    this.now = now;
+    this._installed = false;
+    this._original = null;
+  }
+
+  install() {
+    if (this._installed) return;
+    // Store the raw property so uninstall can restore the exact same reference.
+    this._original = this.host.sendBridgeMessage;
+    const original = this._original.bind(this.host);
+    const self = this;
+    this.host.sendBridgeMessage = function (component, event, data = {}) {
+      self._safeRecord({ direction: "out", component, event, data, ts: self.now() });
+      return original(component, event, data); // pass-through, exactly once
+    };
+    this._installed = true;
+  }
+
+  /** Record an inbound bridge-response payload. */
+  observeResponse(payload) {
+    if (!payload) return;
+    this._safeRecord({
+      direction: "in",
+      component: payload.component,
+      event: payload.event || "response",
+      data: payload.data !== undefined ? payload.data : payload,
+      ts: this.now(),
+    });
+  }
+
+  uninstall() {
+    if (this._installed && this._original) {
+      this.host.sendBridgeMessage = this._original;
+      this._installed = false;
+    }
+  }
+
+  _safeRecord(record) {
+    try {
+      if (this.onRecord) this.onRecord(record);
+    } catch (_e) {
+      /* recording must never break the host */
+    }
+  }
+}

--- a/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/catalog.js
+++ b/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/catalog.js
@@ -1,0 +1,75 @@
+/**
+ * Static catalog of built-in bridge components.
+ * Single source of truth for the Inspector's "Available" list and snippets.
+ * Each entry: { description, erb, stimulus }.
+ */
+export const CATALOG = {
+  "notification": {
+    description: "Show native OS notifications.",
+    erb: `<button data-controller="notification"\n        data-action="click->notification#notify"\n        data-body="Saved!">Notify</button>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "notification") {\n  notify(e) { this.sendBridge("connect", { title: "My App", body: e.target.dataset.body }) }\n}`,
+  },
+  "menu-item": {
+    description: "Register an item in the native menu bar.",
+    erb: `<%= tag.button "Export PDF",\n      **turbo_desktop_bridge("menu-item", title: "Export PDF", shortcut: "Cmd+E") %>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "menu-item") {\n  connect() { super.connect(); this.sendBridge("register", { title: "Export PDF", shortcut: "Cmd+E" }) }\n}`,
+  },
+  "file-picker": {
+    description: "Open a native file open/save dialog.",
+    erb: `<button data-controller="file-picker"\n        data-action="click->file-picker#open">Choose file…</button>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "file-picker") {\n  open() { this.sendBridge("open", { multiple: false }) }\n  receiveBridge(msg) { console.log("picked", msg.data) }\n}`,
+  },
+  "badge": {
+    description: "Set the dock / taskbar badge count.",
+    erb: `<span data-controller="badge" data-badge-count-value="3"></span>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "badge") {\n  static values = { count: Number }\n  connect() { super.connect(); this.sendBridge("set", { count: this.countValue }) }\n}`,
+  },
+  "shortcut": {
+    description: "Register a global keyboard shortcut.",
+    erb: `<div data-controller="shortcut" data-shortcut-keys-value="CmdOrCtrl+K"></div>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "shortcut") {\n  static values = { keys: String }\n  connect() { super.connect(); this.sendBridge("register", { keys: this.keysValue }) }\n  receiveBridge() { /* fired when the shortcut is pressed */ }\n}`,
+  },
+  "shell": {
+    description: "Spawn and manage native shell processes.",
+    erb: `<button data-controller="shell" data-action="click->shell#run">Run</button>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "shell") {\n  run() { TurboDesktop.shell.spawn("job-1", "echo", ["hello"]) }\n}`,
+  },
+  "filesystem": {
+    description: "Read and write files through the native filesystem bridge.",
+    erb: `<button data-controller="fs" data-action="click->fs#read">Read file</button>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "filesystem") {\n  read() { this.sendBridge("read", { path: "~/notes.txt" }) }\n  receiveBridge(msg) { console.log(msg.data) }\n}`,
+  },
+  "sudo": {
+    description: "Run a privileged command via the native elevation prompt.",
+    erb: `<button data-controller="sudo" data-action="click->sudo#elevate">Install</button>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "sudo") {\n  elevate() { this.sendBridge("execute", { command: "brew install foo" }) }\n}`,
+  },
+  "tray": {
+    description: "Add items to the system tray / menu-bar icon.",
+    erb: `<div data-controller="tray" data-tray-title-value="My App"></div>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "tray") {\n  static values = { title: String }\n  connect() { super.connect(); this.sendBridge("set", { tooltip: this.titleValue }) }\n}`,
+  },
+  "deep-link": {
+    description: "Handle custom-scheme deep links opened from outside the app.",
+    erb: `<div data-controller="deep-link"></div>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "deep-link") {\n  receiveBridge(msg) { Turbo.visit(msg.data.path) }\n}`,
+  },
+  "updater": {
+    description: "Check for and apply native app updates.",
+    erb: `<button data-controller="updater" data-action="click->updater#check">Check for updates</button>`,
+    stimulus: `import { Controller } from "@hotwired/stimulus"\nexport default class extends TurboDesktop.stimulusBridge(Controller, "updater") {\n  check() { this.sendBridge("check", {}) }\n  receiveBridge(msg) { console.log("update status", msg.data) }\n}`,
+  },
+};
+
+for (const entry of Object.values(CATALOG)) Object.freeze(entry);
+Object.freeze(CATALOG);
+
+/** Names of every catalogued component. */
+export function listComponents() {
+  return Object.keys(CATALOG);
+}
+
+/** Look up one component's metadata, or null if unknown. */
+export function getComponent(name) {
+  return Object.prototype.hasOwnProperty.call(CATALOG, name) ? CATALOG[name] : null;
+}

--- a/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/panel.js
+++ b/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/panel.js
@@ -1,0 +1,148 @@
+import { listComponents, getComponent } from "./catalog.js";
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replace(/"/g, "&quot;");
+}
+
+/**
+ * Shadow-DOM overlay that renders an InspectorState.
+ * Subscribes to state changes; never mutates state. No Tauri access.
+ */
+export class InspectorPanel {
+  constructor(state, { document }) {
+    this.state = state;
+    this.document = document;
+    this.visible = false;
+    this.activeTab = "components";
+    this.filter = "";
+    this.hostEl = null;
+    this.root = null; // shadow root
+    this._unsub = null;
+  }
+
+  mount(parent) {
+    const host = this.document.createElement("div");
+    host.setAttribute("data-turbo-desktop-inspector", "");
+    host.style.cssText = "position:fixed;right:0;bottom:0;z-index:2147483647;";
+    this.root = host.attachShadow ? host.attachShadow({ mode: "open" }) : host;
+    this.hostEl = host;
+    parent.appendChild(host);
+    this._unsub = this.state.subscribe(() => this.render());
+    this.render();
+    this._applyVisibility();
+    return this;
+  }
+
+  unmount() {
+    if (this._unsub) this._unsub();
+    if (this.hostEl && this.hostEl.parentNode) this.hostEl.parentNode.removeChild(this.hostEl);
+  }
+
+  show() { this.visible = true; this._applyVisibility(); }
+  hide() { this.visible = false; this._applyVisibility(); }
+  toggle() { this.visible = !this.visible; this._applyVisibility(); }
+
+  selectTab(tab) { this.activeTab = tab; this.render(); }
+  setFilter(text) { this.filter = text || ""; this.render(); }
+
+  _applyVisibility() {
+    if (this.hostEl) this.hostEl.style.display = this.visible ? "block" : "none";
+  }
+
+  render() {
+    if (!this.root) return;
+    try {
+      this.root.innerHTML = this._html();
+      this._wire();
+    } catch (_e) {
+      this.root.innerHTML = "<div>&lt;unrenderable&gt;</div>";
+    }
+  }
+
+  _wire() {
+    const q = (sel) => this.root.querySelectorAll(sel);
+    q("[data-tab]").forEach((btn) => {
+      btn.addEventListener("click", () => this.selectTab(btn.dataset.tab));
+    });
+    const input = this.root.querySelector("[data-filter]");
+    if (input) input.addEventListener("input", (e) => this.setFilter(e.target.value));
+  }
+
+  _html() {
+    return `
+      <style>
+        :host { all: initial; }
+        .wrap { font: 12px/1.4 monospace; width: 420px; height: 320px; background:#111; color:#eee; border:1px solid #333; display:flex; flex-direction:column; }
+        .tabs { display:flex; }
+        .tabs button { flex:1; background:#222; color:#ccc; border:0; padding:6px; cursor:pointer; }
+        .tabs button[aria-selected="true"] { background:#0a84ff; color:#fff; }
+        .body { flex:1; overflow:auto; padding:8px; }
+        .row { padding:2px 0; border-bottom:1px solid #222; }
+        .muted { color:#888; }
+        input { width:100%; box-sizing:border-box; margin-bottom:6px; background:#000; color:#eee; border:1px solid #333; }
+      </style>
+      <div class="wrap">
+        <div class="tabs">
+          ${["components", "messages", "navigation", "shell"].map((t) =>
+            `<button data-tab="${t}" aria-selected="${this.activeTab === t}">${t}</button>`).join("")}
+        </div>
+        <div class="body">
+          ${this._panelHtml()}
+        </div>
+      </div>`;
+  }
+
+  _panelHtml() {
+    switch (this.activeTab) {
+      case "messages": return this._messagesHtml();
+      case "navigation": return this._navHtml();
+      case "shell": return this._shellHtml();
+      default: return this._componentsHtml();
+    }
+  }
+
+  _componentsHtml() {
+    const active = new Map(this.state.components().map((c) => [c.name, c]));
+    const rows = listComponents().map((name) => {
+      const c = getComponent(name);
+      const seen = active.get(name);
+      const tag = seen ? `<span>×${escapeHtml(seen.count)} (${escapeHtml(seen.lastEvent)})</span>` : `<span class="muted">available</span>`;
+      return `<div class="row"><strong>${escapeHtml(name)}</strong> ${tag}<br><span class="muted">${escapeHtml(c.description)}</span></div>`;
+    }).join("");
+    return `<div data-panel="components">${rows}</div>`;
+  }
+
+  _messagesHtml() {
+    const f = this.filter.toLowerCase();
+    const rows = this.state.messages
+      .filter((m) => !f || (m.component || "").toLowerCase().includes(f))
+      .map((m) => {
+        const arrow = m.direction === "out" ? "↑" : "↓";
+        return `<div class="row" data-message-row>${arrow} <strong>${escapeHtml(m.component)}</strong> ${escapeHtml(m.event)} <span class="muted">${escapeHtml(JSON.stringify(m.data))}</span></div>`;
+      }).join("");
+    return `<div data-panel="messages"><input data-filter placeholder="filter by component" value="${escapeAttr(this.filter)}">${rows}</div>`;
+  }
+
+  _navHtml() {
+    const n = this.state.nav;
+    return `<div data-panel="navigation"><div class="row">URL: ${escapeHtml(n.url || "—")}</div><div class="row">Presentation: <strong>${escapeHtml(n.presentation || "default")}</strong></div></div>`;
+  }
+
+  _shellHtml() {
+    const s = this.state.shell;
+    return `<div data-panel="shell">
+      <div class="row">Platform: ${escapeHtml(s.platform || "—")}</div>
+      <div class="row">Arch: ${escapeHtml(s.arch || "—")}</div>
+      <div class="row">Version: ${escapeHtml(s.version || "—")}</div>
+      <div class="row">Server: ${escapeHtml(s.serverUrl || "—")}</div>
+      <div class="row">Updater: ${escapeHtml(s.updater || "—")}</div>
+    </div>`;
+  }
+}

--- a/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/state.js
+++ b/turbo_desktop-rails/lib/turbo_desktop/inspector_assets/inspector/state.js
@@ -1,0 +1,61 @@
+/**
+ * In-memory model for the Dev Inspector.
+ * Holds a bounded ring buffer of message records plus a derived component
+ * summary and nav/shell facts. Emits "change" to subscribers. No DOM.
+ */
+export class InspectorState {
+  constructor({ capacity = 200 } = {}) {
+    this.capacity = capacity;
+    this.messages = [];
+    this._components = new Map(); // name -> { count, lastEvent }
+    this.nav = { url: null, presentation: null };
+    this.shell = { platform: null, arch: null, version: null, serverUrl: null, updater: null };
+    this._listeners = new Set();
+  }
+
+  /** Append a record { direction, component, event, data, ts }. */
+  record(record) {
+    this.messages.push(record);
+    if (this.messages.length > this.capacity) this.messages.shift();
+
+    const prev = this._components.get(record.component) || { count: 0, lastEvent: null };
+    prev.count += 1;
+    prev.lastEvent = record.event;
+    this._components.set(record.component, prev);
+
+    this._emit();
+  }
+
+  /** Derived component summary as an array. */
+  components() {
+    return [...this._components.entries()].map(([name, v]) => ({ name, count: v.count, lastEvent: v.lastEvent }));
+  }
+
+  setNav(nav) {
+    this.nav = { ...this.nav, ...nav };
+    this._emit();
+  }
+
+  setShell(shell) {
+    this.shell = { ...this.shell, ...shell };
+    this._emit();
+  }
+
+  clear() {
+    this.messages = [];
+    this._components.clear();
+    this._emit();
+  }
+
+  /** Subscribe to changes; returns an unsubscribe function. */
+  subscribe(fn) {
+    this._listeners.add(fn);
+    return () => this._listeners.delete(fn);
+  }
+
+  _emit() {
+    for (const fn of this._listeners) {
+      try { fn(this); } catch (_e) { /* a bad subscriber must not break others */ }
+    }
+  }
+}

--- a/turbo_desktop-rails/lib/turbo_desktop/view_helpers.rb
+++ b/turbo_desktop-rails/lib/turbo_desktop/view_helpers.rb
@@ -56,11 +56,22 @@ module TurboDesktop
     # when the inspector is disabled. Place in your layout <head>; it is a no-op
     # in production unless you explicitly enable the inspector there.
     #
+    # The tag also carries the same-origin URL of the inspector entry module
+    # (served by this engine) so the desktop shell's turbo-desktop.js can
+    # import() it instead of guessing a relative path.
+    #
     #   <%= turbo_desktop_inspector_meta_tag %>
     def turbo_desktop_inspector_meta_tag
       return nil unless turbo_desktop_inspector?
 
-      tag.meta(name: "turbo-desktop-inspector", content: "enabled")
+      tag.meta(name: "turbo-desktop-inspector", content: "enabled",
+               data: { inspector_url: turbo_desktop_inspector_url })
+    end
+
+    # Same-origin URL of the inspector entry module, under the engine's mount
+    # path (configurable via config.inspector_mount_path).
+    def turbo_desktop_inspector_url
+      "#{TurboDesktop.configuration.inspector_mount_path.chomp("/")}/inspector.js"
     end
   end
 end

--- a/turbo_desktop-rails/test/inspector_assets_controller_test.rb
+++ b/turbo_desktop-rails/test/inspector_assets_controller_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+# Uses the shared app + mounted engine from test_helper.rb.
+class InspectorAssetsControllerTest < ActionDispatch::IntegrationTest
+  def test_serves_inspector_entry_module
+    get "/turbo-desktop/inspector.js"
+    assert_response :success
+    assert_equal "text/javascript", response.media_type
+    assert_includes response.body, "startInspector"
+  end
+
+  def test_serves_every_whitelisted_module
+    %w[inspector.js inspector/state.js inspector/panel.js inspector/bridge-tap.js inspector/catalog.js].each do |asset|
+      get "/turbo-desktop/#{asset}"
+      assert_response :success, "expected #{asset} to be served"
+      assert_equal "text/javascript", response.media_type
+    end
+  end
+
+  def test_submodule_body_is_the_real_module
+    get "/turbo-desktop/inspector/state.js"
+    assert_includes response.body, "class InspectorState"
+  end
+
+  def test_unknown_module_is_not_found
+    get "/turbo-desktop/inspector/nope.js"
+    assert_response :not_found
+  end
+
+  def test_non_whitelisted_ruby_file_is_not_found
+    get "/turbo-desktop/inspector/engine.rb"
+    assert_response :not_found
+  end
+end
+
+# Guards against the vendored copy drifting from the canonical shell source.
+# In the monorepo ../../src is present; in a packaged gem it is not (test skips).
+class InspectorAssetDriftTest < Minitest::Test
+  SHELL_SRC  = File.expand_path("../../src", __dir__)
+  GEM_ASSETS = File.expand_path("../lib/turbo_desktop/inspector_assets", __dir__)
+  FILES = %w[inspector.js inspector/state.js inspector/panel.js inspector/bridge-tap.js inspector/catalog.js].freeze
+
+  def test_vendored_assets_match_shell_source
+    FILES.each do |file|
+      shell = File.join(SHELL_SRC, file)
+      next unless File.exist?(shell) # packaged gem: no shell src to compare against
+
+      assert_equal File.read(shell), File.read(File.join(GEM_ASSETS, file)),
+                   "#{file} drifted from shell src/#{file} — run `rake turbo_desktop:sync_inspector`"
+    end
+  end
+end

--- a/turbo_desktop-rails/test/path_configurations_controller_test.rb
+++ b/turbo_desktop-rails/test/path_configurations_controller_test.rb
@@ -1,26 +1,6 @@
 require "test_helper"
-require "action_controller"
-require "action_dispatch"
 
-# Build a minimal Rails app to test the controller in isolation
-require "rails"
-
-class TestApp < Rails::Application
-  config.eager_load = false
-  config.secret_key_base = "test-secret-key-base-for-turbo-desktop-tests"
-  config.hosts.clear
-end
-
-# Load the engine
-require "turbo_desktop/engine"
-
-TestApp.initialize!
-
-# Draw routes
-Rails.application.routes.draw do
-  mount TurboDesktop::Engine => "/turbo-desktop"
-end
-
+# Uses the shared app + mounted engine from test_helper.rb.
 class PathConfigurationsControllerTest < ActionDispatch::IntegrationTest
   def test_show_returns_json
     get "/turbo-desktop/path-configuration.json"

--- a/turbo_desktop-rails/test/test_helper.rb
+++ b/turbo_desktop-rails/test/test_helper.rb
@@ -12,6 +12,23 @@ require "turbo_desktop/view_helpers"
 require "turbo_desktop/detection"
 require "turbo_desktop/configuration"
 
+# A single shared Rails app + mounted engine for integration tests. Booting
+# more than one Rails::Application in a process is not allowed, so any test that
+# needs routes (path-configuration, inspector assets) uses this one.
+require "rails"
+require "turbo_desktop/engine"
+
+class DummyApp < Rails::Application
+  config.eager_load = false
+  config.secret_key_base = "test-secret-key-base-for-turbo-desktop-tests"
+  config.hosts.clear
+end
+
+Rails.application.initialize! unless Rails.application.initialized?
+Rails.application.routes.draw do
+  mount TurboDesktop::Engine => "/turbo-desktop"
+end
+
 # Reset configuration between tests
 module ConfigurationReset
   def setup

--- a/turbo_desktop-rails/test/view_helpers_test.rb
+++ b/turbo_desktop-rails/test/view_helpers_test.rb
@@ -18,8 +18,15 @@ class ViewHelpersTestHost
   def tag
     @tag ||= Class.new do
       def meta(**attrs)
-        pairs = attrs.map { |k, v| %(#{k.to_s.tr("_", "-")}="#{v}") }.join(" ")
-        "<meta #{pairs}>"
+        flat = []
+        attrs.each do |k, v|
+          if k == :data && v.is_a?(Hash)
+            v.each { |dk, dv| flat << %(data-#{dk.to_s.tr("_", "-")}="#{dv}") }
+          else
+            flat << %(#{k.to_s.tr("_", "-")}="#{v}")
+          end
+        end
+        "<meta #{flat.join(" ")}>"
       end
     end.new
   end
@@ -160,6 +167,8 @@ class ViewHelpersTest < Minitest::Test
     host = ViewHelpersTestHost.new(DESKTOP_UA)
     assert_includes host.turbo_desktop_inspector_meta_tag.to_s, "turbo-desktop-inspector"
     assert_includes host.turbo_desktop_inspector_meta_tag.to_s, "enabled"
+    # carries the same-origin inspector URL (fallback path outside a mounted app)
+    assert_includes host.turbo_desktop_inspector_meta_tag.to_s, 'data-inspector-url="/turbo-desktop/inspector.js"'
   ensure
     TurboDesktop.configuration.inspector_enabled = false
   end


### PR DESCRIPTION
## The bug

The Dev Inspector never loaded in the real desktop app. `turbo-desktop.js` does
`import(window.__TURBO_DESKTOP_INSPECTOR_URL__ || "./inspector.js")` against the **Rails origin**, but nothing set that global and nothing served `inspector.js` there → the import 404'd (silently caught). `tauri.conf.json` bundles `src/` as `frontendDist`, but the WebView origin is the Rails server (`server_url`), not the bundle — so the relative import can't reach it.

## The fix (end-to-end)

- **Gem serves it same-origin.** Vendors the inspector modules into `lib/turbo_desktop/inspector_assets/` and serves them via a whitelisted controller at `/turbo-desktop/inspector.js` (+ `/inspector/*.js`). Strict allow-list (no traversal), `text/javascript` so browsers will `import()` them.
- **Meta tag advertises the URL.** `turbo_desktop_inspector_meta_tag` now emits `data-inspector-url`, built from `config.inspector_mount_path` (default `/turbo-desktop`, override for custom mounts).
- **Shell reads it.** `turbo-desktop.js` resolves the inspector URL as: override global → meta `data-inspector-url` → relative fallback.
- **No drift.** `rake turbo_desktop:sync_inspector` re-vendors from the canonical shell `src/`, and a drift-guard test fails CI if the copy diverges.

## Verification

- Gem tests: serves every whitelisted module (`text/javascript`), 404s unknown/`.rb`, view-helper carries the URL, drift guard. **69 runs, 0 failures.**
- RuboCop clean; JS suite green (62).
- **End-to-end browser check**: `import("/turbo-desktop/inspector.js")` resolves its `./inspector/*.js` sub-imports *under the mount path* and mounts the panel.
- ⚠️ **Native Tauri verification (Mac GUI) still required** before relying on it in front of an audience — I can't drive a native WKWebView window headless.

Closes the P0 "inspector unwired in production" gap. After this, the talk demo needs no `public/` workaround.