### PR TITLE
docs(rails): add 0.1.1 changelog entry

### DIFF
--- a/turbo_desktop-rails/CHANGELOG.md
+++ b/turbo_desktop-rails/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.1.1 (2026-07-27)
+
+### Added
+
+- Install generator: `rails generate turbo_desktop:install` scaffolds the initializer.
+- Dev Inspector support:
+  - `config.inspector_enabled` and the `turbo_desktop_inspector_meta_tag` view helper to enable
+    the in-app inspector overlay (dev only).
+  - The gem now serves the inspector's JavaScript **same-origin** at `/turbo-desktop/inspector.js`
+    (and its sub-modules), so the desktop shell can `import()` it without extra setup.
+  - `config.inspector_mount_path` to match a custom engine mount point.
+
+### Changed
+
+- Minimum Ruby version is now 3.3.
+
 ## 0.0.1 (2026-03-22)
 
 - Initial release


### PR DESCRIPTION
Documents 0.1.1 before publishing to RubyGems: install generator, Dev Inspector (enable flag, meta-tag helper, same-origin asset serving, configurable mount path), and the Ruby 3.3 floor.