### PR TITLE
ci: add tag-triggered release workflow + distribution docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+# Cut a release by pushing a tag:  git tag v0.1.0 && git push origin v0.1.0
+# This builds installers for macOS (universal), Windows, and Linux, and attaches
+# them to a draft GitHub Release. Tauri can't cross-compile, so each OS builds on
+# its own runner.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch: # lets you run it manually from the Actions tab
+
+jobs:
+  release:
+    permissions:
+      contents: write # needed to create the release + upload assets
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest # universal .dmg (Intel + Apple Silicon)
+            args: "--target universal-apple-darwin"
+          - platform: ubuntu-latest # .deb + .AppImage
+            args: ""
+          - platform: windows-latest # .msi + NSIS .exe
+            args: ""
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # macOS universal binary needs both arches
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # --- Optional code signing / notarization ------------------------------
+          # Set these repo secrets to ship SIGNED builds. Leave unset for unsigned
+          # builds (which trigger Gatekeeper / SmartScreen warnings on users' machines).
+          # macOS (Developer ID + notarization):
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Auto-updater signing (only if you use the updater plugin):
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "Turbo Desktop ${{ github.ref_name }}"
+          releaseBody: "Download the installer for your platform below."
+          releaseDraft: true # review before publishing
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -264,6 +264,19 @@ The `turbo_desktop-rails` gem gives your Rails app awareness of the desktop shel
 | Binary size | System WebKit | ~20 MB | ~5-10 MB |
 | Platforms | iOS, iPadOS | Android | macOS, Windows, Linux |
 
+## Distribution
+
+Ship native installers for macOS, Windows, and Linux by pushing a git tag — the
+[release workflow](.github/workflows/release.yml) builds each OS and attaches the installers to a
+draft GitHub Release:
+
+```bash
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+See **[docs/DISTRIBUTION.md](docs/DISTRIBUTION.md)** for local builds, using it in your own app,
+and the optional signing / auto-update setup.
+
 ## Project Structure
 
 ```

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,80 @@
+# Distributing a Turbo Desktop app
+
+Turbo Desktop apps are [Tauri](https://tauri.app) apps, so distribution means producing native
+installers per OS. This guide covers the easy path (a release workflow), local builds, and the
+optional-but-recommended signing/update setup.
+
+## TL;DR — cut a release by pushing a tag
+
+This repo ships [`.github/workflows/release.yml`](../.github/workflows/release.yml). To release:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+CI then builds on three runners (Tauri can't cross-compile) and attaches installers to a **draft
+GitHub Release** for you to review and publish:
+
+| Platform | You get |
+|----------|---------|
+| macOS (universal) | `.dmg` + `.app` (runs on Intel **and** Apple Silicon) |
+| Windows | `.msi` + NSIS `.exe` |
+| Linux | `.deb` + `.AppImage` |
+
+You can also run it manually from the **Actions → Release → Run workflow** button.
+
+## What ships inside the app
+
+Turbo Desktop follows the Hotwire Native model: the shell loads `server_url` from
+`turbo-desktop.config.json`, baked in at build time. So a distributed app is a **thin native shell
+pointing at your hosted Rails app** — you ship the binary, your Rails app is the product. Set
+`server_url` to your production URL before building for release.
+
+## Building locally (to test a bundle)
+
+```bash
+npm run build                    # cargo tauri build — bundles for the current OS
+npm run build:apple-silicon      # arm64 macOS only
+```
+Output: `src-tauri/target/release/bundle/`.
+
+## Using this in your own app
+
+`npx turbo-desktop new myapp` scaffolds a `desktop/` project. To get the same one-tag releases,
+copy `release.yml` into your app's `.github/workflows/` and adjust `projectPath` if your Tauri
+project isn't at the repo root. Everything else (matrix, deps, draft release) works as-is.
+
+## Signing & notarization (recommended before shipping to real users)
+
+Unsigned builds trigger Gatekeeper (macOS) and SmartScreen (Windows) warnings. The workflow reads
+signing material from repo **secrets** — set them and builds sign automatically; leave them unset
+for unsigned builds.
+
+- **macOS** (Apple Developer ID + notarization): `APPLE_CERTIFICATE`,
+  `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`,
+  `APPLE_TEAM_ID`.
+- **Windows** (Authenticode): configure `bundle.windows.certificateThumbprint` (or a signing
+  command) in `tauri.conf.json`.
+
+See the Tauri signing guides: [macOS](https://tauri.app/distribute/sign/macos/) ·
+[Windows](https://tauri.app/distribute/sign/windows/).
+
+## Auto-update (optional)
+
+`tauri.conf.json` includes the `updater` plugin, but `endpoints` and `pubkey` are empty — updates
+are **off** until you configure them:
+
+1. Generate a keypair: `npx tauri signer generate`.
+2. Put the public key in `tauri.conf.json` → `plugins.updater.pubkey` and add your update-server
+   `endpoints`.
+3. Add the private key + password as the `TAURI_SIGNING_PRIVATE_KEY` /
+   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets (the release workflow already passes them through).
+
+Details: [Tauri updater](https://tauri.app/plugin/updater/).
+
+## Status
+
+- ✅ Cross-OS installers via one tag (this workflow).
+- ⚙️ Signing / notarization — wired for secrets, you supply the certs.
+- ⚙️ Auto-update — plugin present, endpoints/keys not yet configured.


### PR DESCRIPTION
Makes distribution approachable — **push a tag, get installers.**

## What

- **`.github/workflows/release.yml`** — on a `v*` tag (or manual dispatch), builds on macOS (universal), Windows, and Linux runners via [`tauri-action`](https://github.com/tauri-apps/tauri-action) and attaches `.dmg` / `.msi` / `.deb` / `.AppImage` to a **draft** GitHub Release. Signing + updater keys are read from repo secrets when set, so unsigned builds still work out of the box.
- **`docs/DISTRIBUTION.md`** — tag-to-release flow, local builds (`npm run build`), reusing the workflow in your own `npx turbo-desktop new` app, and optional macOS notarization / Windows signing / auto-update setup. Status stated honestly (installers ✅; signing + update = you supply the certs/keys).
- **README** — a Distribution section linking both.

## Notes

- Tauri can't cross-compile, hence the 3-runner matrix (each OS builds its own bundle).
- `frontendDist` is static (`../src`), so there's no frontend build step — `tauri-action` just bundles.
- The release workflow only runs on tags/dispatch, so it doesn't affect PR CI. First real release is cutting `v0.1.0` when you're ready.