### PR TITLE
fix(ci): add "tauri" npm script so tauri-action can build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "turbo-desktop": "./cli/turbo-desktop.js"
   },
   "scripts": {
+    "tauri": "tauri",
     "dev": "cargo tauri dev",
     "build": "cargo tauri build",
     "build:apple-silicon": "cargo tauri build --target aarch64-apple-darwin",


### PR DESCRIPTION
The first release run (tag v0.1.1) failed on all three OS legs with `npm error Missing script: "tauri"`. `tauri-action` invokes `npm run tauri build`, but `package.json` only had `cargo tauri`-based scripts. Adds `"tauri": "tauri"` (backed by the `@tauri-apps/cli` devDependency).

Verified locally: `npm run tauri -- --version` → `tauri-cli 2.11.4`.