### PR TITLE
fix(ci): unsigned macOS builds by default + official site link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,19 +53,23 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # --- Optional code signing / notarization ------------------------------
-          # Set these repo secrets to ship SIGNED builds. Leave unset for unsigned
-          # builds (which trigger Gatekeeper / SmartScreen warnings on users' machines).
-          # macOS (Developer ID + notarization):
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # --- Code signing (opt-in) ---------------------------------------------
+          # Builds are UNSIGNED by default (they work, but trigger Gatekeeper /
+          # SmartScreen warnings). To ship SIGNED macOS builds, UNCOMMENT the block
+          # below and set the matching repo secrets. Do NOT leave these set to empty
+          # secrets — an empty APPLE_CERTIFICATE makes Tauri try (and fail) to import
+          # an empty keychain certificate.
+          #
+          # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # APPLE_ID: ${{ secrets.APPLE_ID }}
+          # APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          #
           # Auto-updater signing (only if you use the updater plugin):
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          # TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Turbo Desktop ${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 </p>
 
 <p align="center">
+  <strong>🌐 Official site: <a href="https://turbo-desktop.dev/">turbo-desktop.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://turbo-desktop.dev/">Website</a> •
   <a href="#features">Features</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#quick-start">Quick Start</a> •

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -47,9 +47,10 @@ project isn't at the repo root. Everything else (matrix, deps, draft release) wo
 
 ## Signing & notarization (recommended before shipping to real users)
 
-Unsigned builds trigger Gatekeeper (macOS) and SmartScreen (Windows) warnings. The workflow reads
-signing material from repo **secrets** — set them and builds sign automatically; leave them unset
-for unsigned builds.
+Unsigned builds trigger Gatekeeper (macOS) and SmartScreen (Windows) warnings. Builds are **unsigned
+by default** so a first release just works. To sign, **uncomment the signing block** in
+`release.yml` and set the matching repo **secrets** (don't leave the env set to empty secrets — an
+empty `APPLE_CERTIFICATE` makes Tauri try, and fail, to import an empty certificate).
 
 - **macOS** (Apple Developer ID + notarization): `APPLE_CERTIFICATE`,
   `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`,
@@ -76,5 +77,9 @@ Details: [Tauri updater](https://tauri.app/plugin/updater/).
 ## Status
 
 - ✅ Cross-OS installers via one tag (this workflow).
-- ⚙️ Signing / notarization — wired for secrets, you supply the certs.
+- ⚙️ Signing / notarization — opt-in (uncomment the block + supply certs).
 - ⚙️ Auto-update — plugin present, endpoints/keys not yet configured.
+
+---
+
+More at the official site: **[turbo-desktop.dev](https://turbo-desktop.dev/)**.


### PR DESCRIPTION
Third release-build issue: the macOS leg compiled + built the universal binary, then failed at **codesign** — `security import: failed to import keychain certificate`. An unset `APPLE_CERTIFICATE` secret is passed as an empty string, and Tauri tries to import an empty cert. (Windows + Linux don't codesign, so they succeeded — the draft `v0.1.1` release already has their `.msi`/`.exe`/`.deb`/`.AppImage`/`.rpm`.)

- **Comment out the signing env** so unsigned macOS builds succeed by default; signing is opt-in (uncomment + set real secrets).
- Docs: signing documented as opt-in.
- Adds the **official site link, [turbo-desktop.dev](https://turbo-desktop.dev/)**, to the README + distribution doc.