### PR TITLE
ci: run Rust checks on Linux, macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,20 @@ jobs:
       - run: npm test
 
   rust:
-    name: Rust Check
-    runs-on: ubuntu-latest
+    name: Rust Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
       - name: Install system dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y \


### PR DESCRIPTION
## Why

The shell compiles and ships to macOS, Linux and Windows (release workflow), but CI only ever built and tested it on Linux. Platform breaks — Unix-only spawn paths, missing shells, path assumptions — currently surface at release-build time or on a user's machine.

## What

- `rust` job becomes a 3-OS matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`
- `fail-fast: false` so one platform failing still reports the others
- `Swatinem/rust-cache` keeps the tripled job affordable
- apt system deps stay Linux-only

## Note for branch protection

Job name changes from `Rust Check` to `Rust Check (<os>)` — required status checks need updating to match.

This is step 1 of cross-platform validation; known Windows runtime gaps (`SHELL`-based spawns in `server.rs` / `shell_bridge.rs`, `osascript` sudo bridge) come separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)