### PR TITLE
fix: spawn processes through cmd on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,10 @@ first:
 }
 ```
 
-- `command` runs through your login shell, so a Ruby version manager (rbenv,
-  asdf, mise) is set up the same way it would be in a terminal.
+- `command` runs through your login shell on macOS and Linux, so a Ruby version
+  manager (rbenv, asdf, mise) is set up the same way it would be in a terminal.
+  On Windows it runs through `cmd`, and the Unix `bin/rails` binstub does not
+  apply — set `command` to `ruby bin\rails server` there.
 - `directory` is resolved relative to the config file and defaults to `..` —
   the project root, one level above `desktop/`.
 

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -48,9 +48,9 @@ pub fn working_directory(config: &ServerConfig, config_dir: Option<&Path>) -> Op
 
 /// Start the configured server and hand it to ProcessManager.
 ///
-/// Run through a login shell because starting a Rails app usually depends on a
-/// version manager that only sets itself up in a configured shell — the same
-/// reason the shell bridge does it.
+/// The command runs the way the platform runs commands — through a login shell
+/// on Unix (a version manager only sets itself up in a configured shell),
+/// through `cmd` on Windows. See [`crate::shell_bridge::shell_invocation`].
 pub async fn start(
     app: &tauri::AppHandle,
     config: &ServerConfig,
@@ -65,12 +65,10 @@ pub async fn start(
     };
     let directory = working_directory(config, config_dir);
 
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-    let mut spawner = tokio::process::Command::new(&shell);
+    let (program, args) = crate::shell_bridge::shell_invocation(command);
+    let mut spawner = tokio::process::Command::new(&program);
     spawner
-        .arg("-l")
-        .arg("-c")
-        .arg(command)
+        .args(&args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 

--- a/src-tauri/src/shell_bridge.rs
+++ b/src-tauri/src/shell_bridge.rs
@@ -63,11 +63,9 @@ async fn handle_spawn(
         format!("{} {}", command, args.iter().map(|a| shell_escape(a)).collect::<Vec<_>>().join(" "))
     };
 
-    let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-    let mut cmd = tokio::process::Command::new(&user_shell);
-    cmd.arg("-l")
-        .arg("-c")
-        .arg(&shell_command)
+    let (program, shell_args) = shell_invocation(&shell_command);
+    let mut cmd = tokio::process::Command::new(&program);
+    cmd.args(&shell_args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .envs(&env);
@@ -227,13 +225,101 @@ async fn handle_list(app: &tauri::AppHandle) -> Result<serde_json::Value, String
     serde_json::to_value(&processes).map_err(|e| format!("{}", e))
 }
 
+/// How to run a command line on this platform.
+///
+/// On Unix the command runs through the user's login shell, so a version
+/// manager (rbenv, nvm, mise) sets up PATH the same way it would in a
+/// terminal. Windows has no login-shell convention — PATH comes from the
+/// registry and is already present — so the command goes through `cmd /C`.
+pub fn shell_invocation(command: &str) -> (String, Vec<String>) {
+    #[cfg(windows)]
+    {
+        (
+            "cmd".to_string(),
+            vec!["/C".to_string(), command.to_string()],
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        (
+            shell,
+            vec!["-l".to_string(), "-c".to_string(), command.to_string()],
+        )
+    }
+}
+
 /// Escape a string for safe inclusion in a shell command.
+#[cfg(not(windows))]
 fn shell_escape(s: &str) -> String {
     if s.is_empty() {
         return "''".to_string();
     }
-    if s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | '@')) {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | '@'))
+    {
         return s.to_string();
     }
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Escape for `cmd /C`: double quotes around anything with spaces or cmd
+/// metacharacters, with embedded quotes doubled. cmd has no single-quote
+/// syntax, so the Unix escaping above would pass the quotes to the program.
+#[cfg(windows)]
+fn shell_escape(s: &str) -> String {
+    if s.is_empty() {
+        return "\"\"".to_string();
+    }
+    if s.chars().all(|c| {
+        c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | '@' | '\\')
+    }) {
+        return s.to_string();
+    }
+    format!("\"{}\"", s.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(windows))]
+    #[test]
+    fn commands_run_through_a_login_shell() {
+        let (program, args) = shell_invocation("bin/rails server");
+        assert_eq!(
+            program,
+            std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into())
+        );
+        assert_eq!(args, vec!["-l", "-c", "bin/rails server"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn commands_run_through_cmd() {
+        // No login shell on Windows: PATH is already there, and `sh -l -c`
+        // would need a shell that does not exist.
+        let (program, args) = shell_invocation("bin/rails server");
+        assert_eq!(program, "cmd");
+        assert_eq!(args, vec!["/C", "bin/rails server"]);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn arguments_are_single_quoted_for_the_shell() {
+        assert_eq!(shell_escape("plain-arg.txt"), "plain-arg.txt");
+        assert_eq!(shell_escape("has space"), "'has space'");
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+        assert_eq!(shell_escape(""), "''");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn arguments_are_double_quoted_for_cmd() {
+        assert_eq!(shell_escape("plain-arg.txt"), "plain-arg.txt");
+        assert_eq!(shell_escape(r"C:\Users\dev"), r"C:\Users\dev");
+        assert_eq!(shell_escape("has space"), "\"has space\"");
+        assert_eq!(shell_escape("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(shell_escape(""), "\"\"");
+    }
 }

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -42,8 +42,8 @@ pub struct TurboDesktopConfig {
 /// first. Left empty, the shell expects a server that is already running.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ServerConfig {
-    /// Run through a login shell, so a Ruby version manager is set up the same
-    /// way it would be in a terminal.
+    /// Runs through a login shell on Unix, so a Ruby version manager is set up
+    /// the same way it would be in a terminal; through `cmd` on Windows.
     #[serde(default)]
     pub command: Option<String>,
     /// Where to run it, relative to this config file. Defaults to `..`, which


### PR DESCRIPTION
## Why

Both process-spawn paths — server auto-start (`server.rs`) and the shell bridge (`shell_bridge.rs`) — ran `$SHELL -l -c <command>` with hardcoded Unix fallbacks (`/bin/sh`, `/bin/zsh`). On Windows neither `SHELL` nor `/bin` exists, so every spawn failed: the app sat on the waiting page forever and the shell bridge returned errors.

## What

- New `shell_invocation()` helper decides per platform: the user's login shell on Unix (version managers like rbenv/nvm/mise only configure themselves there), `cmd /C` on Windows (PATH comes from the registry; there is no login-shell convention).
- Both spawn sites use it.
- `shell_escape` splits per platform too: cmd has no single-quote syntax, so the Unix escaping would have handed literal quotes to the program. Windows escaping uses double quotes with embedded quotes doubled.
- Shell-bridge fallback unified from `/bin/zsh` to `/bin/sh` (zsh was a macOS guess; minimal Linux systems don't have it).
- Platform-specific unit tests run on the new 3-OS CI matrix — the Windows tests actually execute on `windows-latest`.
- README documents that Windows needs `ruby bin\rails server` (Unix binstub doesn't apply).

Remaining known Windows gap (separate work): the sudo bridge shells out to `osascript` (macOS-only); it needs UAC on Windows and `pkexec` on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)