### PR TITLE
feat: a dialog-picked path is consent to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,12 @@ out of a root, and locations like `.ssh`, `.aws`, `.gnupg` and Rails
 }
 ```
 
+A path the user picks in a native file dialog is treated as consent for that
+path: picking a file (open or save) makes that one file readable and writable,
+picking a folder covers everything inside it. So "Save As… → Desktop" works
+without listing `~/Desktop` as a root. Grants last for the session only, and
+the protected locations above stay refused even when picked.
+
 **Sudo.** The `sudo` component is off unless you enable it and name the commands
 it may run. A command is matched whole or as a prefix up to a word boundary, and
 anything containing shell metacharacters (`;`, `&&`, `|`, backticks, `$(...)`)

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -134,6 +134,7 @@ async fn handle_file_picker(
     app: &tauri::AppHandle,
     message: &BridgeMessage,
 ) -> Result<serde_json::Value, String> {
+    use tauri::Manager;
     use tauri_plugin_dialog::DialogExt;
 
     let title = message.data["title"].as_str().unwrap_or("Select");
@@ -150,7 +151,12 @@ async fn handle_file_picker(
                 });
 
             match rx.await {
-                Ok(Some(path)) => Ok(serde_json::json!({ "status": "selected", "path": path })),
+                Ok(Some(path)) => {
+                    // Picking a folder is consent for everything in it.
+                    app.state::<crate::security::UserGrants>()
+                        .grant_folder(&path);
+                    Ok(serde_json::json!({ "status": "selected", "path": path }))
+                }
                 Ok(None) => Ok(serde_json::json!({ "status": "cancelled", "path": null })),
                 Err(e) => Err(format!("Dialog error: {}", e)),
             }
@@ -166,7 +172,11 @@ async fn handle_file_picker(
                 });
 
             match rx.await {
-                Ok(Some(path)) => Ok(serde_json::json!({ "status": "selected", "path": path })),
+                Ok(Some(path)) => {
+                    // Picking a file is consent for that file.
+                    app.state::<crate::security::UserGrants>().grant_file(&path);
+                    Ok(serde_json::json!({ "status": "selected", "path": path }))
+                }
                 Ok(None) => Ok(serde_json::json!({ "status": "cancelled", "path": null })),
                 Err(e) => Err(format!("Dialog error: {}", e)),
             }
@@ -182,7 +192,11 @@ async fn handle_file_picker(
                 });
 
             match rx.await {
-                Ok(Some(path)) => Ok(serde_json::json!({ "status": "selected", "path": path })),
+                Ok(Some(path)) => {
+                    // Choosing where to save is consent to write there.
+                    app.state::<crate::security::UserGrants>().grant_file(&path);
+                    Ok(serde_json::json!({ "status": "selected", "path": path }))
+                }
                 Ok(None) => Ok(serde_json::json!({ "status": "cancelled", "path": null })),
                 Err(e) => Err(format!("Dialog error: {}", e)),
             }

--- a/src-tauri/src/fs_bridge.rs
+++ b/src-tauri/src/fs_bridge.rs
@@ -15,17 +15,27 @@ pub async fn handle_filesystem(
     app: &tauri::AppHandle,
     message: &BridgeMessage,
 ) -> Result<serde_json::Value, String> {
-    let roots = configured_roots(app);
+    let scope = FsScope {
+        roots: configured_roots(app),
+        grants: app.state::<security::UserGrants>(),
+    };
 
     match message.event.as_str() {
-        "read" => handle_read(message, &roots).await,
-        "write" => handle_write(message, &roots).await,
-        "exists" => handle_exists(message, &roots).await,
-        "list" => handle_list(message, &roots).await,
-        "mkdir" => handle_mkdir(message, &roots).await,
-        "remove" => handle_remove(message, &roots).await,
+        "read" => handle_read(message, &scope).await,
+        "write" => handle_write(message, &scope).await,
+        "exists" => handle_exists(message, &scope).await,
+        "list" => handle_list(message, &scope).await,
+        "mkdir" => handle_mkdir(message, &scope).await,
+        "remove" => handle_remove(message, &scope).await,
         _ => Ok(serde_json::json!({ "status": "unknown_event" })),
     }
+}
+
+/// Where this app may reach: the configured roots, plus whatever the user has
+/// granted through a native file dialog this session.
+struct FsScope<'a> {
+    roots: Vec<PathBuf>,
+    grants: tauri::State<'a, security::UserGrants>,
 }
 
 /// Roots this app may touch, defaulting to its own data directory.
@@ -35,26 +45,26 @@ fn configured_roots(app: &tauri::AppHandle) -> Vec<PathBuf> {
     security::allowed_roots(app_data_dir, &config.filesystem)
 }
 
-/// Pull the `path` field out of a message and resolve it inside the allowed roots.
+/// Pull the `path` field out of a message and resolve it inside the scope.
 fn scoped_path(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
     event: &str,
 ) -> Result<PathBuf, String> {
     let raw = message.data["path"]
         .as_str()
         .ok_or_else(|| format!("Missing 'path' in filesystem {}", event))?;
 
-    security::resolve_in_scope(raw, roots).inspect_err(|e| {
+    security::resolve_with_grants(raw, &scope.roots, &scope.grants).inspect_err(|e| {
         log::warn!("Filesystem: {}", e);
     })
 }
 
 async fn handle_read(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
 ) -> Result<serde_json::Value, String> {
-    let path = scoped_path(message, roots, "read")?;
+    let path = scoped_path(message, scope, "read")?;
 
     match fs::read_to_string(&path).await {
         Ok(content) => Ok(serde_json::json!({ "status": "ok", "content": content })),
@@ -64,13 +74,13 @@ async fn handle_read(
 
 async fn handle_write(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
 ) -> Result<serde_json::Value, String> {
     let content = message.data["content"]
         .as_str()
         .ok_or("Missing 'content' in filesystem write")?;
     let append = message.data["append"].as_bool().unwrap_or(false);
-    let path = scoped_path(message, roots, "write")?;
+    let path = scoped_path(message, scope, "write")?;
 
     let result = if append {
         let mut file = fs::OpenOptions::new()
@@ -92,9 +102,9 @@ async fn handle_write(
 
 async fn handle_exists(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
 ) -> Result<serde_json::Value, String> {
-    let path = scoped_path(message, roots, "exists")?;
+    let path = scoped_path(message, scope, "exists")?;
 
     match fs::metadata(&path).await {
         Ok(meta) => Ok(serde_json::json!({
@@ -114,9 +124,9 @@ async fn handle_exists(
 
 async fn handle_list(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
 ) -> Result<serde_json::Value, String> {
-    let path = scoped_path(message, roots, "list")?;
+    let path = scoped_path(message, scope, "list")?;
 
     let mut entries = Vec::new();
     let mut dir = match fs::read_dir(&path).await {
@@ -143,9 +153,9 @@ async fn handle_list(
 
 async fn handle_mkdir(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
 ) -> Result<serde_json::Value, String> {
-    let path = scoped_path(message, roots, "mkdir")?;
+    let path = scoped_path(message, scope, "mkdir")?;
 
     match fs::create_dir_all(&path).await {
         Ok(()) => Ok(serde_json::json!({ "status": "ok" })),
@@ -155,10 +165,10 @@ async fn handle_mkdir(
 
 async fn handle_remove(
     message: &BridgeMessage,
-    roots: &[PathBuf],
+    scope: &FsScope<'_>,
 ) -> Result<serde_json::Value, String> {
     let recursive = message.data["recursive"].as_bool().unwrap_or(false);
-    let path = scoped_path(message, roots, "remove")?;
+    let path = scoped_path(message, scope, "remove")?;
 
     let result = match fs::metadata(&path).await {
         Ok(meta) if meta.is_dir() && recursive => fs::remove_dir_all(&path).await,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
         .manage(process_manager::ProcessManager::new())
         .manage(window::LastWindowSize::default())
         .manage(window::FocusTracker::default())
+        .manage(security::UserGrants::default())
         // Inject turbo-desktop.js into every page load across all webviews.
         .on_page_load(|webview, payload| {
             if let PageLoadEvent::Finished = payload.event() {

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -256,6 +256,74 @@ pub fn allowed_roots(app_data_dir: Option<PathBuf>, config: &FilesystemConfig) -
         .collect()
 }
 
+/// Paths the user has handed to the app through a native dialog this session.
+///
+/// A file the user picks in an open/save dialog is explicit consent for that
+/// path, so it does not also need to be inside `allowed_roots` — requiring
+/// that would force apps to allowlist the whole home directory to make
+/// "Save As…" work. Picking a file grants that one path; picking a folder
+/// grants its subtree. Grants live in memory only, so consent ends with the
+/// session.
+#[derive(Default)]
+pub struct UserGrants(std::sync::Mutex<Vec<Grant>>);
+
+struct Grant {
+    path: PathBuf,
+    subtree: bool,
+}
+
+impl UserGrants {
+    /// Record a file the user picked in a dialog.
+    pub fn grant_file(&self, path: &str) {
+        self.push(path, false);
+    }
+
+    /// Record a folder the user picked in a dialog, covering everything in it.
+    pub fn grant_folder(&self, path: &str) {
+        self.push(path, true);
+    }
+
+    fn push(&self, path: &str, subtree: bool) {
+        let normalized = canonicalize_existing_prefix(&lexical_normalize(Path::new(path)));
+        self.0.lock().unwrap().push(Grant {
+            path: normalized,
+            subtree,
+        });
+    }
+
+    fn allows(&self, resolved: &Path) -> bool {
+        self.0.lock().unwrap().iter().any(|grant| {
+            resolved == grant.path || (grant.subtree && resolved.starts_with(&grant.path))
+        })
+    }
+}
+
+/// Like [`resolve_in_scope`], but a path the user granted through a dialog is
+/// also allowed. The protected-location denials still apply — a grant widens
+/// where the app may go, never past what is denied outright.
+pub fn resolve_with_grants(
+    raw: &str,
+    roots: &[PathBuf],
+    grants: &UserGrants,
+) -> Result<PathBuf, String> {
+    let refused = match resolve_in_scope(raw, roots) {
+        Ok(path) => return Ok(path),
+        Err(e) => e,
+    };
+
+    let expanded = expand_tilde(raw).filter(|p| p.is_absolute());
+    let Some(expanded) = expanded else {
+        return Err(refused);
+    };
+
+    let resolved = canonicalize_existing_prefix(&lexical_normalize(&expanded));
+    if !is_denied(&resolved) && grants.allows(&resolved) {
+        Ok(resolved)
+    } else {
+        Err(refused)
+    }
+}
+
 /// Decide whether a command may run with administrator privileges.
 ///
 /// Sudo is off unless the app turns it on and names the commands it needs.
@@ -503,6 +571,82 @@ mod tests {
         let err = resolve_in_scope("/tmp/anything", &[])
             .expect_err("an empty root list should refuse everything");
         assert!(err.contains("no allowed roots"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn a_dialog_picked_file_is_reachable_outside_the_roots() {
+        let dir = std::env::temp_dir().join("turbo-desktop-grant-file");
+        std::fs::create_dir_all(&dir).unwrap();
+        let picked = dir.canonicalize().unwrap().join("report.csv");
+
+        let grants = UserGrants::default();
+        let roots = [PathBuf::from("/nonexistent-root")];
+
+        let raw = picked.to_string_lossy().to_string();
+        assert!(resolve_with_grants(&raw, &roots, &grants).is_err());
+
+        grants.grant_file(&raw);
+        let resolved =
+            resolve_with_grants(&raw, &roots, &grants).expect("a picked file should be reachable");
+        assert_eq!(resolved, picked);
+
+        // The grant covers that one file, not its siblings.
+        let sibling = dir.join("other.csv").to_string_lossy().to_string();
+        assert!(resolve_with_grants(&sibling, &roots, &grants).is_err());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_dialog_picked_folder_covers_its_subtree() {
+        let dir = std::env::temp_dir().join("turbo-desktop-grant-folder");
+        std::fs::create_dir_all(&dir).unwrap();
+        let folder = dir.canonicalize().unwrap();
+
+        let grants = UserGrants::default();
+        grants.grant_folder(&folder.to_string_lossy());
+
+        let inside = folder.join("nested").join("file.txt");
+        let resolved = resolve_with_grants(&inside.to_string_lossy(), &[], &grants)
+            .expect("a path inside the picked folder should be reachable");
+        assert_eq!(resolved, inside);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_grant_does_not_override_protected_locations() {
+        let dir = std::env::temp_dir().join("turbo-desktop-grant-denied");
+        std::fs::create_dir_all(&dir).unwrap();
+        let folder = dir.canonicalize().unwrap();
+
+        let grants = UserGrants::default();
+        grants.grant_folder(&folder.to_string_lossy());
+
+        let secret = folder.join(".ssh").join("id_rsa");
+        assert!(resolve_with_grants(&secret.to_string_lossy(), &[], &grants).is_err());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_grant_cannot_be_reached_by_traversal_from_a_root() {
+        // A granted path must match after normalization, so `root/../granted`
+        // resolves to the grant itself and is allowed, while unrelated
+        // traversal keeps failing.
+        let dir = std::env::temp_dir().join("turbo-desktop-grant-traversal");
+        std::fs::create_dir_all(&dir).unwrap();
+        let picked = dir.canonicalize().unwrap().join("picked.txt");
+
+        let grants = UserGrants::default();
+        grants.grant_file(&picked.to_string_lossy());
+
+        let dodged = dir.join("sub").join("..").join("picked.txt");
+        let resolved = resolve_with_grants(&dodged.to_string_lossy(), &[], &grants)
+            .expect("normalized path should match the grant");
+        assert_eq!(resolved, picked);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Why

The file picker returned any path the user chose, but the filesystem bridge refused everything outside `allowed_roots`. The natural "Save As… → Desktop" flow therefore failed unless the app allowlisted the whole home directory — which defeats the point of the roots policy.

## What

A native-dialog selection is explicit user consent for that path, so it is now granted for the session:

- Picking a file (open **or** save dialog) makes that one file readable and writable — not its siblings.
- Picking a folder covers its subtree.
- Grants are in-memory only; consent ends with the session.
- Granted paths go through the same normalization as the roots check (`..`, symlink-prefix resolution), so a grant cannot be forged by traversal.
- Protected locations (`.ssh`, `.aws`, `master.key`, `credentials.yml.enc`, …) stay refused even when explicitly picked.

Mechanically: new `UserGrants` state in `security.rs`, registered in managed state; the three file-picker handlers record selections; `fs_bridge` resolves through `resolve_with_grants`, which falls back to the grant set only after the roots check refuses.

Four new security tests cover: file grant works and doesn't leak to siblings, folder grant covers subtree, grants don't override denials, normalization applies to grant matching.