### PR TITLE
feat: files dragged onto the app reach the web layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,27 @@ it arrives in full when the command finishes.
 
 Set `confirm` to `false` only if your app already asks the user itself.
 
+### Drag & drop from the desktop
+
+Files dragged from the Finder or Explorer onto any app window reach your page
+with their real paths — something a browser never gives you. The drop counts as
+consent, like a dialog pick: the dropped files (and folders, with their
+contents) become readable through the filesystem bridge for the session.
+
+Subscribe from a Stimulus controller with plain DOM events:
+
+```js
+// data-action="turbo-desktop:drop@document->importer#filesDropped"
+filesDropped(event) {
+  const { paths, position } = event.detail;
+  paths.forEach((path) => TurboDesktop.fs.read(path));
+}
+```
+
+`turbo-desktop:drag-enter` and `turbo-desktop:drag-leave` fire around it for
+hover styling, or use the callback API: `TurboDesktop.dragDrop.onDrop(cb)`,
+`.onEnter(cb)`, `.onLeave(cb)`.
+
 ### Dev Inspector
 
 In development, press **Cmd/Ctrl+Shift+D** to open the Dev Inspector — an in-app

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -243,3 +243,75 @@ async fn handle_shortcut(
         _ => Ok(serde_json::json!({ "status": "unknown_event" })),
     }
 }
+
+/// Forward a native drag-drop interaction to the web layer.
+///
+/// The webview's native handler owns file drags, so the page never sees the
+/// dropped files through HTML5 events — this hands it the paths instead.
+/// Dropping a file onto the app is the same consent as picking it in a
+/// dialog, so the paths are granted for the session before the event goes
+/// out. `Over` is not forwarded: it fires for every mouse move.
+pub fn handle_drag_drop(app: &tauri::AppHandle, event: &tauri::DragDropEvent) {
+    use tauri::DragDropEvent;
+    use tauri::Manager;
+
+    match event {
+        DragDropEvent::Enter { paths, position } => {
+            emit_drag_drop(app, "enter", drag_drop_payload(paths, Some(position)));
+        }
+        DragDropEvent::Drop { paths, position } => {
+            let grants = app.state::<crate::security::UserGrants>();
+            for path in paths {
+                let raw = path.to_string_lossy();
+                if path.is_dir() {
+                    grants.grant_folder(&raw);
+                } else {
+                    grants.grant_file(&raw);
+                }
+            }
+            emit_drag_drop(app, "drop", drag_drop_payload(paths, Some(position)));
+        }
+        DragDropEvent::Leave => {
+            emit_drag_drop(app, "leave", serde_json::json!({ "paths": [] }));
+        }
+        _ => {}
+    }
+}
+
+fn emit_drag_drop(app: &tauri::AppHandle, event: &str, data: serde_json::Value) {
+    let response = BridgeResponse {
+        component: "drag-drop".to_string(),
+        event: event.to_string(),
+        data,
+    };
+    if let Err(e) = app.emit("bridge-response", &response) {
+        log::warn!("Drag-drop: failed to emit '{}': {}", event, e);
+    }
+}
+
+fn drag_drop_payload(
+    paths: &[std::path::PathBuf],
+    position: Option<&tauri::PhysicalPosition<f64>>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "paths": paths.iter().map(|p| p.to_string_lossy()).collect::<Vec<_>>(),
+        "position": position.map(|p| serde_json::json!({ "x": p.x, "y": p.y })),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_drop_payload_carries_paths_and_position() {
+        let paths = vec![std::path::PathBuf::from("/tmp/report.csv")];
+        let position = tauri::PhysicalPosition { x: 10.0, y: 20.0 };
+
+        let payload = drag_drop_payload(&paths, Some(&position));
+
+        assert_eq!(payload["paths"][0], "/tmp/report.csv");
+        assert_eq!(payload["position"]["x"], 10.0);
+        assert_eq!(payload["position"]["y"], 20.0);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,13 @@ fn main() {
         .manage(window::LastWindowSize::default())
         .manage(window::FocusTracker::default())
         .manage(security::UserGrants::default())
+        // Files dragged from the Finder/Explorer onto any window reach the web
+        // layer as bridge events, with their paths granted for the session.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::DragDrop(drag) = event {
+                bridge::handle_drag_drop(window.app_handle(), drag);
+            }
+        })
         // Inject turbo-desktop.js into every page load across all webviews.
         .on_page_load(|webview, payload| {
             if let PageLoadEvent::Finished = payload.event() {

--- a/src/turbo-desktop.js
+++ b/src/turbo-desktop.js
@@ -320,7 +320,65 @@
         });
       },
     },
+
+    // ─── Drag & Drop API ─────────────────────────────────────────────────────
+    //
+    // Files dragged from the Finder/Explorer arrive here with their real
+    // paths (the shell also grants them for reading, like a dialog pick).
+    // Also dispatched as DOM events for Stimulus actions:
+    //   turbo-desktop:drag-enter, turbo-desktop:drop, turbo-desktop:drag-leave
+    // with { paths, position } in event.detail.
+
+    dragDrop: {
+      onDrop(callback) {
+        return this._listen("drop", callback);
+      },
+
+      onEnter(callback) {
+        return this._listen("enter", callback);
+      },
+
+      onLeave(callback) {
+        return this._listen("leave", callback);
+      },
+
+      _listen(name, callback) {
+        if (!window.__TAURI_INTERNALS__?.event?.listen) return null;
+        return window.__TAURI_INTERNALS__.event.listen(
+          "bridge-response",
+          (event) => {
+            const payload = event.payload;
+            if (
+              payload &&
+              payload.component === "drag-drop" &&
+              payload.event === name
+            ) {
+              callback(payload.data);
+            }
+          }
+        );
+      },
+    },
   };
+
+  // Surface drag-drop as DOM events so a Stimulus controller can subscribe
+  // with a plain action instead of the TurboDesktop API.
+  if (window.__TAURI_INTERNALS__?.event?.listen) {
+    const domEventNames = {
+      enter: "turbo-desktop:drag-enter",
+      drop: "turbo-desktop:drop",
+      leave: "turbo-desktop:drag-leave",
+    };
+    window.__TAURI_INTERNALS__.event.listen("bridge-response", (event) => {
+      const payload = event.payload;
+      const name = payload && payload.component === "drag-drop"
+        ? domEventNames[payload.event]
+        : null;
+      if (name) {
+        document.dispatchEvent(new CustomEvent(name, { detail: payload.data }));
+      }
+    });
+  }
 
   // ─── Turbo Drive Integration ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

The webview's native handler owns file drags, so a page never sees dropped files through HTML5 events. Dragging a file onto the window — the first desktop gesture everyone tries — silently did nothing.

## What

- `WindowEvent::DragDrop` is forwarded to the page as bridge events (`enter`, `drop`, `leave`; `over` skipped — it fires per mouse move) with real paths and the drop position.
- A drop is the same consent as a dialog pick (built on #26): dropped files are granted for the session, folders with their subtree, protected locations still refused.
- JS: `TurboDesktop.dragDrop.onDrop/onEnter/onLeave`, plus DOM CustomEvents (`turbo-desktop:drop`, `:drag-enter`, `:drag-leave`) so a Stimulus controller subscribes with a plain `data-action`.
- README section with the Stimulus example.

**Base is #26** (`feat/picker-consent`) — this reuses its `UserGrants`; GitHub retargets to `main` when that merges.