### PR TITLE
feat: launch-at-login bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,27 @@ await TurboDesktop.clipboard.writeText("INV-2024-001");
 Ordinary copy and paste inside the page keeps working through the webview as
 in any browser.
 
+### Launch at login
+
+Offer a toggle in your app's settings page; the shell records the choice with
+the OS — a Launch Agent on macOS, the registry `Run` key on Windows, an XDG
+autostart entry on Linux:
+
+```js
+// A Stimulus controller behind a checkbox
+async toggle(event) {
+  if (event.target.checked) await TurboDesktop.autostart.enable();
+  else await TurboDesktop.autostart.disable();
+}
+
+async connect() {
+  this.checkboxTarget.checked = await TurboDesktop.autostart.isEnabled();
+}
+```
+
+It is deliberately not a config key: registering login items silently is how
+apps end up on "why does this start with my computer" lists. Ask first.
+
 ### Dev Inspector
 
 In development, press **Cmd/Ctrl+Shift+D** to open the Dev Inspector — an in-app

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -288,6 +288,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,11 +934,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -938,7 +969,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1080,7 +1111,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3644,6 +3675,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4628,7 +4670,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4678,7 +4720,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4747,6 +4789,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4894,7 +4950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5426,7 +5482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5472,6 +5528,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
@@ -6493,6 +6550,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6623,7 +6689,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ regex-lite = "0.1"
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-deep-link = "2.4.9"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-autostart = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -62,6 +62,7 @@ pub async fn handle_bridge_message(
         "filesystem" => crate::fs_bridge::handle_filesystem(&app, &message).await,
         "sudo" => crate::sudo_bridge::handle_sudo(&app, &message).await,
         "clipboard" => handle_clipboard(&app, &message).await,
+        "autostart" => handle_autostart(&app, &message).await,
         "updater" => crate::updater_bridge::handle_updater(&app, &message).await,
         _ => {
             // Forward unknown components as events — allows user-defined bridge components
@@ -323,6 +324,43 @@ async fn handle_clipboard(
                 .write_text(text.to_string())
                 .map_err(|e| format!("Could not write to the clipboard: {}", e))?;
             Ok(serde_json::json!({ "status": "ok" }))
+        }
+        _ => Ok(serde_json::json!({ "status": "unknown_event" })),
+    }
+}
+
+/// Launch-at-login, driven by the app's own settings page.
+///
+/// Left to the user rather than the config: registering login items
+/// silently is how apps end up in "why does this start with my computer"
+/// lists. The app asks, the user decides, this records it with the OS
+/// (Launch Agent on macOS, registry Run key on Windows, XDG autostart
+/// entry on Linux).
+async fn handle_autostart(
+    app: &tauri::AppHandle,
+    message: &BridgeMessage,
+) -> Result<serde_json::Value, String> {
+    use tauri_plugin_autostart::ManagerExt;
+
+    let autolaunch = app.autolaunch();
+    match message.event.as_str() {
+        "enable" => {
+            autolaunch
+                .enable()
+                .map_err(|e| format!("Could not enable launch at login: {}", e))?;
+            Ok(serde_json::json!({ "status": "ok", "enabled": true }))
+        }
+        "disable" => {
+            autolaunch
+                .disable()
+                .map_err(|e| format!("Could not disable launch at login: {}", e))?;
+            Ok(serde_json::json!({ "status": "ok", "enabled": false }))
+        }
+        "status" => {
+            let enabled = autolaunch
+                .is_enabled()
+                .map_err(|e| format!("Could not read the launch-at-login state: {}", e))?;
+            Ok(serde_json::json!({ "status": "ok", "enabled": enabled }))
         }
         _ => Ok(serde_json::json!({ "status": "unknown_event" })),
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,6 +38,10 @@ fn main() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(process_manager::ProcessManager::new())
         .manage(window::LastWindowSize::default())

--- a/src/turbo-desktop.js
+++ b/src/turbo-desktop.js
@@ -381,6 +381,30 @@
         });
       },
     },
+
+    // ─── Autostart API ───────────────────────────────────────────────────────
+    //
+    // Launch-at-login, meant to be driven by a toggle in the app's own
+    // settings page rather than turned on silently.
+
+    autostart: {
+      async enable() {
+        return TurboDesktop.sendBridgeMessage("autostart", "enable", {});
+      },
+
+      async disable() {
+        return TurboDesktop.sendBridgeMessage("autostart", "disable", {});
+      },
+
+      async isEnabled() {
+        const result = await TurboDesktop.sendBridgeMessage(
+          "autostart",
+          "status",
+          {}
+        );
+        return Boolean(result && result.enabled);
+      },
+    },
   };
 
   // Surface drag-drop as DOM events so a Stimulus controller can subscribe


### PR DESCRIPTION
## Why

A desktop app that should always be running — a tray-first tool, anything that notifies — needs to start with the user's session. There was no way to request that.

## What

- New `autostart` bridge component backed by `tauri-plugin-autostart`: `enable`, `disable`, `status`.
- Recorded with the OS natively: Launch Agent on macOS, registry `Run` key on Windows, XDG autostart entry on Linux.
- JS: `TurboDesktop.autostart.enable()` / `.disable()` / `.isEnabled()`.
- README shows the intended shape: a checkbox in the app's settings page.

Deliberately **not** a config key — registering login items silently is how apps end up on "why does this start with my computer" lists. The app asks, the user decides.

Independent of the #26–#28 chain; based on `main`.