### PR TITLE
feat: files opened via OS association reach the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,34 @@ async connect() {
 It is deliberately not a config key: registering login items silently is how
 apps end up on "why does this start with my computer" lists. Ask first.
 
+### Opening files with your app
+
+Declare the file types your app owns in `tauri.conf.json`, and the OS offers
+your app for them — double-click, "Open With…", drop on the dock icon:
+
+```json
+{
+  "bundle": {
+    "fileAssociations": [
+      { "ext": ["csv"], "description": "Data import", "role": "Viewer" }
+    ]
+  }
+}
+```
+
+Opened files arrive as a `turbo-desktop:file-open` DOM event with
+`event.detail.paths`, whether the app was already running or was launched by
+the double-click — a launch queues the paths until your page is up. Like a
+dialog pick, being asked to open a file grants it for reading through the
+filesystem bridge.
+
+```js
+// data-action="turbo-desktop:file-open@document->importer#fileOpened"
+async fileOpened(event) {
+  const { content } = await TurboDesktop.fs.read(event.detail.paths[0]);
+}
+```
+
 ### Dev Inspector
 
 In development, press **Cmd/Ctrl+Shift+D** to open the Dev Inspector — an in-app

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -63,6 +63,15 @@ pub async fn handle_bridge_message(
         "sudo" => crate::sudo_bridge::handle_sudo(&app, &message).await,
         "clipboard" => handle_clipboard(&app, &message).await,
         "autostart" => handle_autostart(&app, &message).await,
+        // The page drains files the OS asked the app to open. Pull rather than
+        // push: a launch-by-double-click happens before any page exists.
+        "file-open" => match message.event.as_str() {
+            "pending" => Ok(serde_json::json!({
+                "status": "ok",
+                "paths": crate::deep_link::drain_pending(&app),
+            })),
+            _ => Ok(serde_json::json!({ "status": "unknown_event" })),
+        },
         "updater" => crate::updater_bridge::handle_updater(&app, &message).await,
         _ => {
             // Forward unknown components as events — allows user-defined bridge components

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -82,12 +82,89 @@ pub fn handle(app: &tauri::AppHandle, urls: Vec<url::Url>) {
     }
 }
 
+/// Files the OS asked the app to open, waiting for the page to collect them.
+///
+/// A file association launch usually happens before the page has loaded, so a
+/// pushed event would land in an empty webview. The paths queue here instead:
+/// the shell pings the page, and the page drains the queue through the bridge
+/// — on its own startup if the ping arrived too early.
+#[derive(Default)]
+pub struct PendingOpenedFiles(std::sync::Mutex<Vec<String>>);
+
+/// Handle files the OS handed to the app — a double-click on an associated
+/// type, "Open With…", or a file dropped on the app's icon.
+pub fn handle_files(app: &tauri::AppHandle, paths: Vec<std::path::PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+
+    // Being asked to open a file is the same consent as picking it in a
+    // dialog, so the page can read what it was handed.
+    let grants = app.state::<crate::security::UserGrants>();
+    let mut opened: Vec<String> = Vec::new();
+    for path in &paths {
+        let raw = path.to_string_lossy().into_owned();
+        if path.is_dir() {
+            grants.grant_folder(&raw);
+        } else {
+            grants.grant_file(&raw);
+        }
+        log::info!("Opening from the OS: {}", raw);
+        opened.push(raw);
+    }
+
+    app.state::<PendingOpenedFiles>()
+        .0
+        .lock()
+        .unwrap()
+        .extend(opened);
+
+    // Ping a loaded page so it drains the queue now; a page that is not there
+    // yet misses the ping and drains on its own startup instead.
+    if let Some(window) = app.get_webview_window("main") {
+        crate::window::deliver_to_page(&window, "file-open-pending", &serde_json::json!({}));
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Bridge handler: the page collects (and thereby clears) the queued files.
+pub fn drain_pending(app: &tauri::AppHandle) -> Vec<String> {
+    std::mem::take(&mut *app.state::<PendingOpenedFiles>().0.lock().unwrap())
+}
+
+/// The paths the OS launched the app with, on platforms where an associated
+/// file arrives as a plain argument (Windows and Linux; macOS uses an event).
+pub fn paths_from_args<I: Iterator<Item = String>>(args: I) -> Vec<std::path::PathBuf> {
+    args.skip(1)
+        .filter(|arg| !arg.starts_with('-'))
+        .map(std::path::PathBuf::from)
+        .filter(|path| path.exists())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn link(s: &str) -> url::Url {
         url::Url::parse(s).expect("test link should parse")
+    }
+
+    #[test]
+    fn only_existing_non_flag_arguments_are_opened_files() {
+        let file = std::env::temp_dir().join("turbo-desktop-assoc.txt");
+        std::fs::write(&file, "x").unwrap();
+
+        let args = vec![
+            "/usr/bin/app".to_string(),
+            "--flag".to_string(),
+            file.to_string_lossy().into_owned(),
+            "/nonexistent/other.txt".to_string(),
+        ];
+
+        assert_eq!(paths_from_args(args.into_iter()), vec![file.clone()]);
+        std::fs::remove_file(&file).ok();
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,6 +47,7 @@ fn main() {
         .manage(window::LastWindowSize::default())
         .manage(window::FocusTracker::default())
         .manage(security::UserGrants::default())
+        .manage(deep_link::PendingOpenedFiles::default())
         // Files dragged from the Finder/Explorer onto any window reach the web
         // layer as bridge events, with their paths granted for the session.
         .on_window_event(|window, event| {
@@ -247,6 +248,12 @@ fn main() {
                 deep_link::handle(&deep_link_app, event.urls());
             });
 
+            // Files from outside the app: a double-click on an associated
+            // type. Windows and Linux pass them as launch arguments; macOS
+            // raises RunEvent::Opened instead, handled in run() below.
+            #[cfg(not(target_os = "macos"))]
+            deep_link::handle_files(&app_handle, deep_link::paths_from_args(std::env::args()));
+
             // Set up the system tray icon
             if let Err(e) = tray::setup_tray(&app_handle) {
                 log::warn!("Could not set up system tray: {}", e);
@@ -282,6 +289,18 @@ fn main() {
 
                 let pm = app_handle.state::<process_manager::ProcessManager>();
                 tauri::async_runtime::block_on(pm.kill_all());
+            }
+
+            // macOS delivers associated files as an event — at launch or into
+            // the running app. Other platforms pass them as arguments instead,
+            // handled at setup.
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Opened { urls } = &event {
+                let files: Vec<std::path::PathBuf> = urls
+                    .iter()
+                    .filter_map(|url| url.to_file_path().ok())
+                    .collect();
+                deep_link::handle_files(app_handle, files);
             }
         });
 }

--- a/src/turbo-desktop.js
+++ b/src/turbo-desktop.js
@@ -712,10 +712,41 @@
       case "visit":
         performVisit(detail.url);
         break;
+      case "file-open-pending":
+        drainOpenedFiles();
+        break;
       default:
         console.debug("[turbo-desktop] Ignoring unknown message:", kind);
     }
   };
+
+  /**
+   * Collect files the OS asked the app to open (double-click on an associated
+   * type, "Open With…"), announced as a turbo-desktop:file-open DOM event.
+   *
+   * Pull rather than push: launching by double-click queues the file in the
+   * shell before any page exists, so the page asks — on its own startup, and
+   * again whenever the shell pings a running page.
+   */
+  async function drainOpenedFiles() {
+    try {
+      const result = await TurboDesktop.sendBridgeMessage(
+        "file-open",
+        "pending",
+        {}
+      );
+      const paths = result && result.paths;
+      if (Array.isArray(paths) && paths.length > 0) {
+        document.dispatchEvent(
+          new CustomEvent("turbo-desktop:file-open", { detail: { paths } })
+        );
+      }
+    } catch (_e) {
+      // Not running inside the shell, or the bridge is not ready.
+    }
+  }
+
+  drainOpenedFiles();
 
   /**
    * True when someone is part-way through entering something.

--- a/test/turbo-desktop.test.js
+++ b/test/turbo-desktop.test.js
@@ -226,7 +226,11 @@ describe("TurboDesktop.sendBridgeMessage", () => {
 
     const result = await window.TurboDesktop.sendBridgeMessage("notification", "show", { title: "Hello" });
 
-    const bridgeCall = calls.find((c) => c.cmd === "handle_bridge_message");
+    // The script also sends its own startup messages (e.g. draining files the
+    // OS asked the app to open), so look for this call rather than the first.
+    const bridgeCall = calls.find(
+      (c) => c.cmd === "handle_bridge_message" && c.args.message.component === "notification"
+    );
     assert.ok(bridgeCall);
     assertDeepEqual(bridgeCall.args.message, {
       component: "notification",
@@ -330,7 +334,9 @@ describe("BridgeComponent", () => {
     const instance = new TestComponent(el);
     const result = await instance.send("activate", { color: "red" });
 
-    const bridgeCall = calls.find((c) => c.cmd === "handle_bridge_message");
+    const bridgeCall = calls.find(
+      (c) => c.cmd === "handle_bridge_message" && c.args.message.component === "test-widget"
+    );
     assert.ok(bridgeCall);
     assert.strictEqual(bridgeCall.args.message.component, "test-widget");
     assert.strictEqual(bridgeCall.args.message.event, "activate");


### PR DESCRIPTION
Replaces #28 (closed by the base-branch-deletion/force-push interaction while the PR chain merged). Same change, rebased onto main.

## Why

Declaring `bundle.fileAssociations` in `tauri.conf.json` makes the OS offer the app for a file type — but the opened file went nowhere. macOS's open event and the argv path on Windows/Linux were both ignored, so double-clicking an associated file just focused the app.

## What

- Opened paths queue in the shell (`PendingOpenedFiles`) and the page **drains** them through a new `file-open` bridge component, announced as a `turbo-desktop:file-open` DOM event with `detail.paths`.
- Pull rather than push: the common case — app launched *by* the double-click — happens before any page exists, so a pushed event would land in an empty webview. The page drains on its own startup; a running page gets pinged and drains immediately. Atomic drain means no double-delivery.
- Platform sources: macOS `RunEvent::Opened` (also covers drop-on-dock-icon); Windows/Linux launch arguments, filtered to non-flag arguments that exist on disk.
- Being asked to open a file is consent (#26): the path is granted for the session.
- Two JS tests updated: they asserted the *first* bridge call was theirs, which the startup drain call broke — they now find their call by component.
- README documents `fileAssociations` config + a Stimulus example.